### PR TITLE
fix typo in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ action "On sync" {
 }
 
 action "Apply labels" {
-  uses = "actions/labeller@v1.0.0"
+  uses = "actions/labeler@v1.0.0"
   needs = "On sync"
   env = {LABEL_SPEC_FILE=".github/triage.yml"}
   secrets = ["GITHUB_TOKEN"]


### PR DESCRIPTION
resolves #1 

Fixes typo in the action's github repository name in the workflow file example.