### PR TITLE
Fetch configuration content from PR ref

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,36 +1,41 @@
 {
-  "name": "node12-template-action",
-  "version": "0.0.0",
+  "name": "labeler",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "file:toolkit/actions-core-0.0.0.tgz",
-      "integrity": "sha512-P+mC79gXC2yvyU0+RDctxKUI1Q3tNruB+aSmFI47j2H0DylxtDEgycW9WXwt/zCY62lfwfvBoGKpuJRvFHDqpw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.0.0.tgz",
+      "integrity": "sha512-aMIlkx96XH4E/2YZtEOeyrYQfhlas9jIRkfGPqMwXD095Rdkzo4lB6ZmbxPQSzD+e1M+Xsm98ZhuSMYGv/AlqA=="
     },
     "@actions/exec": {
-      "version": "file:toolkit/actions-exec-0.0.0.tgz",
-      "integrity": "sha512-HHObusC4p1RElxIlrrN0sY/cweBYl+jKm3J/XWHPQZMipgJXB/dkVhUfl4KqH3Vim7oM2KjCGSfn+vTYrqVH3A=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.0.0.tgz",
+      "integrity": "sha512-nquH0+XKng+Ll7rZfCojN7NWSbnGh+ltwUJhzfbLkmOJgxocGX2/yXcZLMyT9fa7+tByEow/NSTrBExNlEj9fw=="
     },
     "@actions/github": {
-      "version": "file:toolkit/actions-github-0.0.0.tgz",
-      "integrity": "sha512-CByX5VIagC5BqGwsHD9Qt5MfN+H6GDC9qQl+MIUipaHTc89sUG/vAY/xQDS9vxuuRwrxbdERwKO3dR6U1BSziw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-1.0.0.tgz",
+      "integrity": "sha512-PPbWZ5wFAD/Vr+RCECfR3KNHjTwYln4liJBihs9tQUL0/PCFqB2lSkIh9V94AcZFHxgKk8snImjuLaBE8bKR7A==",
       "requires": {
         "@octokit/graphql": "^2.0.1",
         "@octokit/rest": "^16.15.0"
       }
     },
     "@actions/io": {
-      "version": "file:toolkit/actions-io-0.0.0.tgz",
-      "integrity": "sha512-BZqiiacJkzERkYIMUQWrujLZWSFHEA6bD/LzR7QSDHpx32+PPk7NaUNmt8CG+y+OlYPc/ZZGaY3368K1ppfptA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.0.tgz",
+      "integrity": "sha512-ezrJSRdqtXtdx1WXlfYL85+40F7gB39jCK9P0jZVODW3W6xUYmu6ZOEc/UmmElUwhRyDRm1R4yNZu1Joq2kuQg=="
     },
     "@actions/tool-cache": {
-      "version": "file:toolkit/actions-tool-cache-0.0.0.tgz",
-      "integrity": "sha512-CCJjXKGfqR34oo1mgKpUk63g3fcoIq+aNJBZ7b73aWGot0ddju2cefJrKjhEun4FI7gYsLYg+ayAUnbFwkGd4Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.0.0.tgz",
+      "integrity": "sha512-l3zT0IfDfi5Ik5aMpnXqGHGATxN8xa9ls4ue+X/CBXpPhRMRZS4vcuh5Q9T98WAGbkysRCfhpbksTPHIcKnNwQ==",
       "requires": {
-        "@actions/core": "^0.0.0",
-        "@actions/exec": "^0.0.0",
-        "@actions/io": "^0.0.0",
+        "@actions/core": "^1.0.0",
+        "@actions/exec": "^1.0.0",
+        "@actions/io": "^1.0.0",
         "semver": "^6.1.0",
         "typed-rest-client": "^1.4.0",
         "uuid": "^3.3.2"
@@ -1907,8 +1912,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1929,14 +1933,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1951,20 +1953,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2081,8 +2080,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2094,7 +2092,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2109,7 +2106,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2117,14 +2113,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2143,7 +2137,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2224,8 +2217,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2237,7 +2229,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2323,8 +2314,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2360,7 +2350,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2380,7 +2369,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2424,14 +2412,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "file:toolkit/actions-core-0.0.0.tgz",
-    "@actions/exec": "file:toolkit/actions-exec-0.0.0.tgz",
-    "@actions/github": "file:toolkit/actions-github-0.0.0.tgz",
-    "@actions/io": "file:toolkit/actions-io-0.0.0.tgz",
-    "@actions/tool-cache": "file:toolkit/actions-tool-cache-0.0.0.tgz",
+    "@actions/core": "^1.0.0",
+    "@actions/exec": "^1.0.0",
+    "@actions/github": "^1.0.0",
+    "@actions/io": "^1.0.0",
+    "@actions/tool-cache": "^1.0.0",
     "js-yaml": "^3.13.1",
     "minimatch": "^3.0.4",
     "semver": "^6.1.1"

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,7 +92,8 @@ async function fetchContent(
   const response = await client.repos.getContents({
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
-    path: repoPath
+    path: repoPath,
+    ref: github.context.sha
   });
 
   return Buffer.from(response.data.content, 'base64').toString();


### PR DESCRIPTION
Fixes #6

When fetching the configuration content from the file specified by `configuration-path`, we should load the content from the ref of the PR.

By default, `repos.getContents` will [use the repository's default branch][1] if no `ref` is specified.

When first configuring this action, assuming the configuration file is added in the same PR as the action, the configuration file will not exist on the default branch. This causes an `HttpError: Not Found` to occur when attempting to load the configuration from the default branch.

This commit updates the call to `getContents` to add the `ref` parameter, set to the `GITHUB_SHA` value from the context. This will cause the action to load the contents of the configuration file from the ref of the PR, rather than the default branch.

---

This PR also updates the packages to use version 1.0.0 of all the toolkit action packages, as they were using local files before.

I noticed that `src/main.ts` is not formatted according to the prettier rules. I'm happy to open another PR that applies prettier to the current source. I had to disable prettier during implementation of this commit in order to keep the changes relevant to this PR.

[1]: https://developer.github.com/v3/repos/contents/#get-contents