### PR TITLE
Add support for regex globs and labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ test:
   - src/**/*.spec.js
 ```
 
+#### RegExp Examples
+
+```yml
+resource/$1:
+  - package\\/resource_(\\w*?)(_test)?.go
+```
+
 ### Create Workflow
 
 Create a workflow (eg: `.github/workflows/labeler.yml` see [Creating a Workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)) to utilize the labeler action with content:

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,4 +1,29 @@
-describe('TODO - Add a test suite', () => {
-  it('TODO - Add a test', async () => {
+import * as labeler from '../src/labeler';
+
+describe('Labeler', () => {
+  it('should parse globs and create labels', async () => {
+    
+    const labelGlobs = new Map([
+      ['core', [ 
+        'core/*.js', 
+        'core/**/*.js']
+      ],
+      ['resource/$1', [ 
+        'package\\/resource_(\\w*?)(_test)?.go' ]
+      ],
+    ]);
+
+    const files = [
+      'package/resource_foo.go',
+      'package/resource_foo_test.go',
+      'core/foo.js',
+      'core/foo/foo.js'
+    ];
+
+    const labels = labeler.getLabels(labelGlobs, files);
+    
+    expect(labels).toHaveLength(2);
+    expect(labels).toContain('resource/foo');
+    expect(labels).toContain('core');
   });
 });

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,29 +1,23 @@
-import * as labeler from '../src/labeler';
+import * as labeler from "../src/labeler";
 
-describe('Labeler', () => {
-  it('should parse globs and create labels', async () => {
-    
+describe("Labeler", () => {
+  it("should parse globs and create labels", async () => {
     const labelGlobs = new Map([
-      ['core', [ 
-        'core/*.js', 
-        'core/**/*.js']
-      ],
-      ['resource/$1', [ 
-        'package\\/resource_(\\w*?)(_test)?.go' ]
-      ],
+      ["core", ["core/*.js", "core/**/*.js"]],
+      ["resource/$1", ["package\\/resource_(\\w*?)(_test)?.go"]]
     ]);
 
     const files = [
-      'package/resource_foo.go',
-      'package/resource_foo_test.go',
-      'core/foo.js',
-      'core/foo/foo.js'
+      "package/resource_foo.go",
+      "package/resource_foo_test.go",
+      "core/foo.js",
+      "core/foo/foo.js"
     ];
 
     const labels = labeler.getLabels(labelGlobs, files);
-    
+
     expect(labels).toHaveLength(2);
-    expect(labels).toContain('resource/foo');
-    expect(labels).toContain('core');
+    expect(labels).toContain("resource/foo");
+    expect(labels).toContain("core");
   });
 });

--- a/lib/labeler.js
+++ b/lib/labeler.js
@@ -9,8 +9,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const minimatch_1 = require("minimatch");
-function label(labelGlobs, files) {
-    const labels = [];
+function getLabels(labelGlobs, files) {
+    const labels = new Set();
     for (const [label, globs] of labelGlobs.entries()) {
         core.debug(`processing ${label}`);
         for (const glob of globs) {
@@ -20,22 +20,20 @@ function label(labelGlobs, files) {
                 core.debug(` - ${file}`);
                 if (matcher.match(file)) {
                     core.debug(` ${file} matches glob ${glob}`);
-                    labels.push(label);
+                    labels.add(label);
                     continue;
                 }
                 try {
                     const regex = new RegExp(glob);
                     if (file.match(regex)) {
                         core.debug(` ${file} matches regex ${regex}`);
-                        labels.push(label.replace(regex, label));
+                        labels.add(file.replace(regex, label));
                     }
                 }
-                catch (e) {
-                    core.error(` failed parsing regex ${glob}: ${e}`);
-                }
+                catch (_a) { }
             }
         }
     }
-    return labels;
+    return Array.from(labels);
 }
-exports.label = label;
+exports.getLabels = getLabels;

--- a/lib/labeler.js
+++ b/lib/labeler.js
@@ -1,0 +1,41 @@
+"use strict";
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const core = __importStar(require("@actions/core"));
+const minimatch_1 = require("minimatch");
+function label(labelGlobs, files) {
+    const labels = [];
+    for (const [label, globs] of labelGlobs.entries()) {
+        core.debug(`processing ${label}`);
+        for (const glob of globs) {
+            core.debug(` checking pattern ${glob}`);
+            const matcher = new minimatch_1.Minimatch(glob);
+            for (const file of files) {
+                core.debug(` - ${file}`);
+                if (matcher.match(file)) {
+                    core.debug(` ${file} matches glob ${glob}`);
+                    labels.push(label);
+                    continue;
+                }
+                try {
+                    const regex = new RegExp(glob);
+                    if (file.match(regex)) {
+                        core.debug(` ${file} matches regex ${regex}`);
+                        labels.push(label.replace(regex, label));
+                    }
+                }
+                catch (e) {
+                    core.error(` failed parsing regex ${glob}: ${e}`);
+                }
+            }
+        }
+    }
+    return labels;
+}
+exports.label = label;

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,129 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const core = __importStar(require("@actions/core"));
+const github = __importStar(require("@actions/github"));
+const yaml = __importStar(require("js-yaml"));
+const minimatch_1 = require("minimatch");
+const labeler = __importStar(require("./labeler"));
+function run() {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const token = core.getInput('repo-token', { required: true });
+            const configPath = core.getInput('configuration-path', { required: true });
+            const prNumber = getPrNumber();
+            if (!prNumber) {
+                console.log('Could not get pull request number from context, exiting');
+                return;
+            }
+            const client = new github.GitHub(token);
+            core.debug(`fetching changed files for pr #${prNumber}`);
+            const changedFiles = yield getChangedFiles(client, prNumber);
+            const labelGlobs = yield getLabelGlobs(client, configPath);
+            const labels = labeler.label(labelGlobs, changedFiles);
+            if (labels.length > 0) {
+                yield addLabels(client, prNumber, labels);
+            }
+        }
+        catch (error) {
+            core.error(error);
+            core.setFailed(error.message);
+        }
+    });
+}
+function getPrNumber() {
+    const pullRequest = github.context.payload.pull_request;
+    if (!pullRequest) {
+        return undefined;
+    }
+    return pullRequest.number;
+}
+function getChangedFiles(client, prNumber) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const listFilesResponse = yield client.pulls.listFiles({
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            pull_number: prNumber
+        });
+        const changedFiles = listFilesResponse.data.map(f => f.filename);
+        core.debug('found changed files:');
+        for (const file of changedFiles) {
+            core.debug('  ' + file);
+        }
+        return changedFiles;
+    });
+}
+function getLabelGlobs(client, configurationPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const configurationContent = yield fetchContent(client, configurationPath);
+        // loads (hopefully) a `{[label:string]: string | string[]}`, but is `any`:
+        const configObject = yaml.safeLoad(configurationContent);
+        // transform `any` => `Map<string,string[]>` or throw if yaml is malformed:
+        return getLabelGlobMapFromObject(configObject);
+    });
+}
+function fetchContent(client, repoPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield client.repos.getContents({
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            path: repoPath,
+            ref: github.context.sha
+        });
+        return Buffer.from(response.data.content, 'base64').toString();
+    });
+}
+function getLabelGlobMapFromObject(configObject) {
+    const labelGlobs = new Map();
+    for (const label in configObject) {
+        if (typeof configObject[label] === 'string') {
+            labelGlobs.set(label, [configObject[label]]);
+        }
+        else if (configObject[label] instanceof Array) {
+            labelGlobs.set(label, configObject[label]);
+        }
+        else {
+            throw Error(`found unexpected type for label ${label} (should be string or array of globs)`);
+        }
+    }
+    return labelGlobs;
+}
+function checkGlobs(changedFiles, globs) {
+    for (const glob of globs) {
+        core.debug(` checking pattern ${glob}`);
+        const matcher = new minimatch_1.Minimatch(glob);
+        for (const changedFile of changedFiles) {
+            core.debug(` - ${changedFile}`);
+            if (matcher.match(changedFile)) {
+                core.debug(` ${changedFile} matches`);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+function addLabels(client, prNumber, labels) {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield client.issues.addLabels({
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            issue_number: prNumber,
+            labels: labels
+        });
+    });
+}
+run();

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,7 +18,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const github = __importStar(require("@actions/github"));
 const yaml = __importStar(require("js-yaml"));
-const minimatch_1 = require("minimatch");
 const labeler = __importStar(require("./labeler"));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -34,7 +33,7 @@ function run() {
             core.debug(`fetching changed files for pr #${prNumber}`);
             const changedFiles = yield getChangedFiles(client, prNumber);
             const labelGlobs = yield getLabelGlobs(client, configPath);
-            const labels = labeler.label(labelGlobs, changedFiles);
+            const labels = labeler.getLabels(labelGlobs, changedFiles);
             if (labels.length > 0) {
                 yield addLabels(client, prNumber, labels);
             }
@@ -101,20 +100,6 @@ function getLabelGlobMapFromObject(configObject) {
         }
     }
     return labelGlobs;
-}
-function checkGlobs(changedFiles, globs) {
-    for (const glob of globs) {
-        core.debug(` checking pattern ${glob}`);
-        const matcher = new minimatch_1.Minimatch(glob);
-        for (const changedFile of changedFiles) {
-            core.debug(` - ${changedFile}`);
-            if (matcher.match(changedFile)) {
-                core.debug(` ${changedFile} matches`);
-                return true;
-            }
-        }
-    }
-    return false;
 }
 function addLabels(client, prNumber, labels) {
     return __awaiter(this, void 0, void 0, function* () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1889,7 +1889,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1910,12 +1911,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1930,17 +1933,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2057,7 +2063,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2069,6 +2076,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2083,6 +2091,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2090,12 +2099,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2114,6 +2125,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2194,7 +2206,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2206,6 +2219,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2291,7 +2305,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2327,6 +2342,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2346,6 +2362,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2389,12 +2406,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -1,0 +1,32 @@
+import * as core from '@actions/core';
+import { Minimatch } from 'minimatch';
+
+export function getLabels(labelGlobs: Map<string, string[]>, files: string[]): string[] {
+
+  const labels = new Set<string>();
+
+  for (const [label, globs] of labelGlobs.entries()) {
+    core.debug(`processing ${label}`);
+    for (const glob of globs) {
+      core.debug(` checking pattern ${glob}`);
+      const matcher = new Minimatch(glob);
+      for (const file of files) {
+        core.debug(` - ${file}`);
+        if (matcher.match(file)) {
+          core.debug(` ${file} matches glob ${glob}`);
+          labels.add(label);
+          continue;
+        }
+        try {
+          const regex = new RegExp(glob);
+          if (file.match(regex)) {
+            core.debug(` ${file} matches regex ${regex}`);
+            labels.add(file.replace(regex, label));
+          }
+        } catch {}
+      }
+    }
+  }
+
+  return Array.from(labels);
+}

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -1,8 +1,10 @@
-import * as core from '@actions/core';
-import { Minimatch } from 'minimatch';
+import * as core from "@actions/core";
+import { Minimatch } from "minimatch";
 
-export function getLabels(labelGlobs: Map<string, string[]>, files: string[]): string[] {
-
+export function getLabels(
+  labelGlobs: Map<string, string[]>,
+  files: string[]
+): string[] {
   const labels = new Set<string>();
 
   for (const [label, globs] of labelGlobs.entries()) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,16 @@
-import * as core from '@actions/core';
-import * as github from '@actions/github';
-import * as yaml from 'js-yaml';
-import * as labeler from './labeler';
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import * as yaml from "js-yaml";
+import * as labeler from "./labeler";
 
 async function run() {
   try {
-    const token = core.getInput('repo-token', { required: true });
-    const configPath = core.getInput('configuration-path', { required: true });
+    const token = core.getInput("repo-token", { required: true });
+    const configPath = core.getInput("configuration-path", { required: true });
 
     const prNumber = getPrNumber();
     if (!prNumber) {
-      console.log('Could not get pull request number from context, exiting');
+      console.log("Could not get pull request number from context, exiting");
       return;
     }
 
@@ -55,9 +55,9 @@ async function getChangedFiles(
 
   const changedFiles = listFilesResponse.data.map(f => f.filename);
 
-  core.debug('found changed files:');
+  core.debug("found changed files:");
   for (const file of changedFiles) {
-    core.debug('  ' + file);
+    core.debug("  " + file);
   }
 
   return changedFiles;
@@ -90,13 +90,13 @@ async function fetchContent(
     ref: github.context.sha
   });
 
-  return Buffer.from(response.data.content, 'base64').toString();
+  return Buffer.from(response.data.content, "base64").toString();
 }
 
 function getLabelGlobMapFromObject(configObject: any): Map<string, string[]> {
   const labelGlobs: Map<string, string[]> = new Map();
   for (const label in configObject) {
-    if (typeof configObject[label] === 'string') {
+    if (typeof configObject[label] === "string") {
       labelGlobs.set(label, [configObject[label]]);
     } else if (configObject[label] instanceof Array) {
       labelGlobs.set(label, configObject[label]);


### PR DESCRIPTION
Adds support for regex globs and ability to replace matched groups in the label. 

I've found myself [repeating the same pattern](https://github.com/alexkappa/terraform-provider-auth0/blob/3511a3de133827d2380aa6ff3d8bf0bc16231deb/.github/labeler.yml) in order to add labels per resource, and thought it might be useful to support regex to allow using a match to customize the label.

Example:

```yml
api/$1:
  - 'api\\/resource_(\\w*?)(_test)?.go'
```

Given the files `api/resource_foo.go`, `api/resource_foo_test.go`, `api/resource_bar.go`, will produce the labels: `api/foo` and `api/bar`.

In order to be able to test this, I had to extract the labelling function into its own file so I could import it on its own (without calling `run()`).

I hope you'll find this useful, in what is already an awesome tool 😃 