### PR TITLE
Add support to schedule.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,11 @@ inputs:
   configuration-path:
     description: 'The path for the label configurations'
     default: '.github/labeler.yml'
+  not-found-label:
+    description: 'The label to apply when no matches were found'
+  operations-per-run:
+    description: 'The maximum number of operations per run, used to control rate limiting'
+    default: 30
 runs:
   using: 'node12'
   main: 'lib/main.js'


### PR DESCRIPTION
Workaround to https://github.com/actions/labeler/issues/12 and https://github.com/actions/labeler/issues/36

When running from scheduled task, it will get every PR and process each one that don’t have tags yet.