### PR TITLE
Fix Code Block Type in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ test:
 
 Create a workflow (eg: `.github/workflows/labeler.yml` see [Creating a Workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)) to utilize the labeler action with content:
 
-```
+```yml
 name: "Pull Request Labeler"
 on:
 - pull_request


### PR DESCRIPTION
The final example in the README.md has not had a language defined, so does not have syntax highlighting. This PR resolves that by setting it to `YML`, the same as the other code blocks.