### PR TITLE
Prettier 2.0.4

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,4 +1,3 @@
-describe('TODO - Add a test suite', () => {
-  it('TODO - Add a test', async () => {
-  });
+describe("TODO - Add a test suite", () => {
+  it("TODO - Add a test", async () => {});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4137,9 +4137,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@zeit/ncc": "^0.21.1",
     "jest": "^24.8.0",
     "jest-circus": "^24.7.1",
-    "prettier": "^1.17.1",
+    "prettier": "2.0.4",
     "ts-jest": "^24.0.2",
     "typescript": "^3.5.1"
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,16 @@
-import * as core from '@actions/core';
-import * as github from '@actions/github';
-import * as yaml from 'js-yaml';
-import {Minimatch} from 'minimatch';
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import * as yaml from "js-yaml";
+import { Minimatch } from "minimatch";
 
 async function run() {
   try {
-    const token = core.getInput('repo-token', {required: true});
-    const configPath = core.getInput('configuration-path', {required: true});
+    const token = core.getInput("repo-token", { required: true });
+    const configPath = core.getInput("configuration-path", { required: true });
 
     const prNumber = getPrNumber();
     if (!prNumber) {
-      console.log('Could not get pull request number from context, exiting');
+      console.log("Could not get pull request number from context, exiting");
       return;
     }
 
@@ -56,14 +56,14 @@ async function getChangedFiles(
   const listFilesResponse = await client.pulls.listFiles({
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
-    pull_number: prNumber
+    pull_number: prNumber,
   });
 
-  const changedFiles = listFilesResponse.data.map(f => f.filename);
+  const changedFiles = listFilesResponse.data.map((f) => f.filename);
 
-  core.debug('found changed files:');
+  core.debug("found changed files:");
   for (const file of changedFiles) {
-    core.debug('  ' + file);
+    core.debug("  " + file);
   }
 
   return changedFiles;
@@ -93,7 +93,7 @@ async function fetchContent(
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
     path: repoPath,
-    ref: github.context.sha
+    ref: github.context.sha,
   });
 
   return Buffer.from(response.data.content, response.data.encoding).toString();
@@ -102,7 +102,7 @@ async function fetchContent(
 function getLabelGlobMapFromObject(configObject: any): Map<string, string[]> {
   const labelGlobs: Map<string, string[]> = new Map();
   for (const label in configObject) {
-    if (typeof configObject[label] === 'string') {
+    if (typeof configObject[label] === "string") {
       labelGlobs.set(label, [configObject[label]]);
     } else if (configObject[label] instanceof Array) {
       labelGlobs.set(label, configObject[label]);
@@ -140,7 +140,7 @@ async function addLabels(
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
     issue_number: prNumber,
-    labels: labels
+    labels: labels,
   });
 }
 


### PR DESCRIPTION
This upgrades us to the latest version of [Prettier](https://prettier.io/). See [the blog post introducing version 2.0](https://prettier.io/blog/2020/03/21/2.0.0.html).

I also switched to pinning an exact version of Prettier, [as suggested in the install docs](https://prettier.io/docs/en/install.html).