### PR TITLE
Pin README example to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3-preview
+    - uses: actions/labeler@master
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@v3-preview
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
 ```


### PR DESCRIPTION
The current README describes features that are only in master, with many of the examples not working with `@v2` or `@v3-preview`. Pin the action version in the sample workflow file to `master`.