### PR TITLE
Update README to use `pull_request_target` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Pull request labeler triages PRs based on the paths that are modified in the PR.
 
-Note that only pull requests being opened from the same repository can be labeled.  This action will not currently work for pull requests from forks -- like is common in open source projects -- because the token for forked pull request workflows does not have write permissions.
-
 ## Usage
 
 ### Create `.github/labeler.yml`
@@ -84,7 +82,7 @@ Create a workflow (eg: `.github/workflows/labeler.yml` see [Creating a Workflow 
 ```
 name: "Pull Request Labeler"
 on:
-- pull_request
+- pull_request_target
 
 jobs:
   triage:


### PR DESCRIPTION
GitHub [has introduced](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) a new event type: `pull_request_target`, which allows to run workflows from base branch and pass a token with write permission.

> In order to solve this, we’ve added a new `pull_request_target` event, which behaves in an almost identical way to the `pull_request` event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. This event can be used in combination with the private repository settings as well.