### PR TITLE
Add ability to apply shared configs from another repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ jobs:
 
 _Note: This grants access to the `GITHUB_TOKEN` so the action can make calls to GitHub's rest API_
 
+### (Optional) Apply any shared configurations
+
+If you have lists of rules for labels & file patterns in a repository that stores shared configurations, you can apply them to multiple other repos rather than having to configure each repo independently. To do this, add a `shared-configurations` setting like this:
+
+```
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        shared-configurations: '["my-org/my-repo/some-path/shared-preset.yml@branchname", "my-org/my-repo/some-path/another-preset.yml@branchname"]'
+```
+
 #### Inputs
 
 Various inputs are defined in [`action.yml`](action.yml) to let you configure the labeler:
@@ -103,4 +122,5 @@ Various inputs are defined in [`action.yml`](action.yml) to let you configure th
 | - | - | - |
 | `repo-token` | Token to use to authorize label changes. Typically the GITHUB_TOKEN secret | N/A |
 | `configuration-path` | The path to the label configuration file | `.github/labeler.yml` |
+| `shared-configurations` | Github locations of shared configuration files | [] |
 | `sync-labels` | Whether or not to remove labels when matching files are reverted or no longer changed by the PR | `false`

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'The path for the label configurations'
     default: '.github/labeler.yml'
     required: false
+  shared-configurations:
+    description: "Github locations of shared configuration files"
+    default: "[]"
+    required: false
   sync-labels:
     description: 'Whether or not to remove labels when matching files are reverted'
     default: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -14553,7 +14553,7 @@ function run() {
             const { data: pullRequest } = yield client.pulls.get({
                 owner: github.context.repo.owner,
                 repo: github.context.repo.repo,
-                pull_number: prNumber,
+                pull_number: prNumber
             });
             core.debug(`fetching changed files for pr #${prNumber}`);
             const changedFiles = yield getChangedFiles(client, prNumber);
@@ -14585,7 +14585,7 @@ function run() {
                 if (checkGlobs(changedFiles, globs)) {
                     labels.push(label);
                 }
-                else if (pullRequest.labels.find((l) => l.name === label)) {
+                else if (pullRequest.labels.find(l => l.name === label)) {
                     labelsToRemove.push(label);
                 }
             }
@@ -14614,10 +14614,10 @@ function getChangedFiles(client, prNumber) {
         const listFilesOptions = client.pulls.listFiles.endpoint.merge({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
-            pull_number: prNumber,
+            pull_number: prNumber
         });
         const listFilesResponse = yield client.paginate(listFilesOptions);
-        const changedFiles = listFilesResponse.map((f) => f.filename);
+        const changedFiles = listFilesResponse.map(f => f.filename);
         core.debug("found changed files:");
         for (const file of changedFiles) {
             core.debug("  " + file);
@@ -14663,7 +14663,7 @@ function getLabelGlobMapFromObject(configObject) {
 function toMatchConfig(config) {
     if (typeof config === "string") {
         return {
-            any: [config],
+            any: [config]
         };
     }
     return config;
@@ -14695,7 +14695,7 @@ function isMatch(changedFile, matchers) {
 }
 // equivalent to "Array.some()" but expanded for debugging and clarity
 function checkAny(changedFiles, globs) {
-    const matchers = globs.map((g) => new minimatch_1.Minimatch(g));
+    const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     core.debug(`  checking "any" patterns`);
     for (const changedFile of changedFiles) {
         if (isMatch(changedFile, matchers)) {
@@ -14708,7 +14708,7 @@ function checkAny(changedFiles, globs) {
 }
 // equivalent to "Array.every()" but expanded for debugging and clarity
 function checkAll(changedFiles, globs) {
-    const matchers = globs.map((g) => new minimatch_1.Minimatch(g));
+    const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     core.debug(` checking "all" patterns`);
     for (const changedFile of changedFiles) {
         if (!isMatch(changedFile, matchers)) {
@@ -14738,17 +14738,17 @@ function addLabels(client, prNumber, labels) {
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             issue_number: prNumber,
-            labels: labels,
+            labels: labels
         });
     });
 }
 function removeLabels(client, prNumber, labels) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield Promise.all(labels.map((label) => client.issues.removeLabel({
+        yield Promise.all(labels.map(label => client.issues.removeLabel({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             issue_number: prNumber,
-            name: label,
+            name: label
         })));
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ async function run() {
     const { data: pullRequest } = await client.pulls.get({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
-      pull_number: prNumber,
+      pull_number: prNumber
     });
 
     core.debug(`fetching changed files for pr #${prNumber}`);
@@ -88,7 +88,7 @@ async function run() {
       core.debug(`processing ${label}`);
       if (checkGlobs(changedFiles, globs)) {
         labels.push(label);
-      } else if (pullRequest.labels.find((l) => l.name === label)) {
+      } else if (pullRequest.labels.find(l => l.name === label)) {
         labelsToRemove.push(label);
       }
     }
@@ -122,11 +122,11 @@ async function getChangedFiles(
   const listFilesOptions = client.pulls.listFiles.endpoint.merge({
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
-    pull_number: prNumber,
+    pull_number: prNumber
   });
 
   const listFilesResponse = await client.paginate(listFilesOptions);
-  const changedFiles = listFilesResponse.map((f) => f.filename);
+  const changedFiles = listFilesResponse.map(f => f.filename);
 
   core.debug("found changed files:");
   for (const file of changedFiles) {
@@ -195,7 +195,7 @@ function getLabelGlobMapFromObject(
 function toMatchConfig(config: StringOrMatchConfig): MatchConfig {
   if (typeof config === "string") {
     return {
-      any: [config],
+      any: [config]
     };
   }
 
@@ -236,7 +236,7 @@ function isMatch(changedFile: string, matchers: IMinimatch[]): boolean {
 
 // equivalent to "Array.some()" but expanded for debugging and clarity
 function checkAny(changedFiles: string[], globs: string[]): boolean {
-  const matchers = globs.map((g) => new Minimatch(g));
+  const matchers = globs.map(g => new Minimatch(g));
   core.debug(`  checking "any" patterns`);
   for (const changedFile of changedFiles) {
     if (isMatch(changedFile, matchers)) {
@@ -251,7 +251,7 @@ function checkAny(changedFiles: string[], globs: string[]): boolean {
 
 // equivalent to "Array.every()" but expanded for debugging and clarity
 function checkAll(changedFiles: string[], globs: string[]): boolean {
-  const matchers = globs.map((g) => new Minimatch(g));
+  const matchers = globs.map(g => new Minimatch(g));
   core.debug(` checking "all" patterns`);
   for (const changedFile of changedFiles) {
     if (!isMatch(changedFile, matchers)) {
@@ -289,7 +289,7 @@ async function addLabels(
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
     issue_number: prNumber,
-    labels: labels,
+    labels: labels
   });
 }
 
@@ -299,12 +299,12 @@ async function removeLabels(
   labels: string[]
 ) {
   await Promise.all(
-    labels.map((label) =>
+    labels.map(label =>
       client.issues.removeLabel({
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,
         issue_number: prNumber,
-        name: label,
+        name: label
       })
     )
   );


### PR DESCRIPTION
We had a use case where we wanted to apply the same label configs to multiple repos so that we could have some cross-cutting concerns across our repos. We stored these configs in our `.github` repo, but we needed a way to apply them without copy-pasting to all our other repos. This PR adds the ability to apply a `shared-configurations` option like this:

```
name: "Pull Request Labeler"
on:
- pull_request_target

jobs:
  triage:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/labeler@main
      with:
        repo-token: "${{ secrets.GITHUB_TOKEN }}"
        shared-configurations: '["my-org/my-repo/some-path/shared-preset.yml@branchname", "my-org/my-repo/some-path/another-preset.yml@branchname"]'
```