### PR TITLE
Fix recursive globbing in our npm `format` script command and run all ts files through prettier 💅

### DIFF
--- a/__mocks__/@actions/github.ts
+++ b/__mocks__/@actions/github.ts
@@ -1,32 +1,32 @@
 export const context = {
   payload: {
     pull_request: {
-      number: 123,
-    },
+      number: 123
+    }
   },
   repo: {
     owner: "monalisa",
-    repo: "helloworld",
-  },
+    repo: "helloworld"
+  }
 };
 
 const mockApi = {
   issues: {
     addLabels: jest.fn(),
-    removeLabel: jest.fn(),
+    removeLabel: jest.fn()
   },
   paginate: jest.fn(),
   pulls: {
     get: jest.fn().mockResolvedValue({}),
     listFiles: {
       endpoint: {
-        merge: jest.fn().mockReturnValue({}),
-      },
-    },
+        merge: jest.fn().mockReturnValue({})
+      }
+    }
   },
   repos: {
-    getContents: jest.fn(),
-  },
+    getContents: jest.fn()
+  }
 };
 
 export const GitHub = jest.fn().mockImplementation(() => mockApi);

--- a/__tests__/labeler.test.ts
+++ b/__tests__/labeler.test.ts
@@ -1,4 +1,4 @@
-import { checkGlobs } from '../src/labeler'
+import { checkGlobs } from "../src/labeler";
 
 import * as core from "@actions/core";
 
@@ -12,15 +12,15 @@ beforeAll(() => {
 
 const matchConfig = [{ any: ["*.txt"] }];
 
-describe('checkGlobs', () => {
-  it('returns true when our pattern does match changed files', () => {
+describe("checkGlobs", () => {
+  it("returns true when our pattern does match changed files", () => {
     const changedFiles = ["foo.txt", "bar.txt"];
     const result = checkGlobs(changedFiles, matchConfig);
 
     expect(result).toBeTruthy();
   });
 
-  it('returns false when our pattern does not match changed files', () => {
+  it("returns false when our pattern does not match changed files", () => {
     const changedFiles = ["foo.docx"];
     const result = checkGlobs(changedFiles, matchConfig);
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -15,7 +15,7 @@ const paginateMock = jest.spyOn(gh, "paginate");
 const getPullMock = jest.spyOn(gh.pulls, "get");
 
 const yamlFixtures = {
-  "only_pdfs.yml": fs.readFileSync("__tests__/fixtures/only_pdfs.yml"),
+  "only_pdfs.yml": fs.readFileSync("__tests__/fixtures/only_pdfs.yml")
 };
 
 afterAll(() => jest.restoreAllMocks());
@@ -33,7 +33,7 @@ describe("run", () => {
       owner: "monalisa",
       repo: "helloworld",
       issue_number: 123,
-      labels: ["touched-a-pdf-file"],
+      labels: ["touched-a-pdf-file"]
     });
   });
 
@@ -51,7 +51,7 @@ describe("run", () => {
     let mockInput = {
       "repo-token": "foo",
       "configuration-path": "bar",
-      "sync-labels": true,
+      "sync-labels": true
     };
 
     jest
@@ -62,8 +62,8 @@ describe("run", () => {
     mockGitHubResponseChangedFiles("foo.txt");
     getPullMock.mockResolvedValue(<any>{
       data: {
-        labels: [{ name: "touched-a-pdf-file" }],
-      },
+        labels: [{ name: "touched-a-pdf-file" }]
+      }
     });
 
     await run();
@@ -74,7 +74,7 @@ describe("run", () => {
       owner: "monalisa",
       repo: "helloworld",
       issue_number: 123,
-      name: "touched-a-pdf-file",
+      name: "touched-a-pdf-file"
     });
   });
 
@@ -82,7 +82,7 @@ describe("run", () => {
     let mockInput = {
       "repo-token": "foo",
       "configuration-path": "bar",
-      "sync-labels": false,
+      "sync-labels": false
     };
 
     jest
@@ -93,8 +93,8 @@ describe("run", () => {
     mockGitHubResponseChangedFiles("foo.txt");
     getPullMock.mockResolvedValue(<any>{
       data: {
-        labels: [{ name: "touched-a-pdf-file" }],
-      },
+        labels: [{ name: "touched-a-pdf-file" }]
+      }
     });
 
     await run();
@@ -106,11 +106,11 @@ describe("run", () => {
 
 function usingLabelerConfigYaml(fixtureName: keyof typeof yamlFixtures): void {
   reposMock.mockResolvedValue(<any>{
-    data: { content: yamlFixtures[fixtureName], encoding: "utf8" },
+    data: { content: yamlFixtures[fixtureName], encoding: "utf8" }
   });
 }
 
 function mockGitHubResponseChangedFiles(...files: string[]): void {
-  const returnValue = files.map((f) => ({ filename: f }));
+  const returnValue = files.map(f => ({ filename: f }));
   paginateMock.mockReturnValue(<any>returnValue);
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "lib/main.js",
   "scripts": {
     "build": "tsc && ncc build lib/main.js",
-    "format": "prettier --write **/*.ts",
-    "format-check": "prettier --check **/*.ts",
+    "format": "prettier --write \"**/*.ts\"",
+    "format-check": "prettier --check \"**/*.ts\"",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
The lack of quotes around our recursive glob pattern was causing us to miss nested directories. No longer!

### BEFORE

```
❍ npm run format

> labeler@3.0.0 format
> prettier --write **/*.ts

__tests__/labeler.test.ts 158ms
__tests__/main.test.ts 41ms
src/labeler.ts 70ms
src/main.ts 11ms
```

### AFTER

```
❍ npm run format

> labeler@3.0.0 format
> prettier --write "**/*.ts"

__mocks__/@actions/github.ts 155ms
__tests__/labeler.test.ts 14ms
__tests__/main.test.ts 38ms
src/labeler.ts 68ms
src/main.ts 9ms
```
