### PR TITLE
Default to github.token

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v3
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
-
-_Note: This grants access to the `GITHUB_TOKEN` so the action can make calls to GitHub's rest API_
 
 #### Inputs
 
@@ -110,7 +106,7 @@ Various inputs are defined in [`action.yml`](action.yml) to let you configure th
 
 | Name | Description | Default |
 | - | - | - |
-| `repo-token` | Token to use to authorize label changes. Typically the GITHUB_TOKEN secret | N/A |
+| `repo-token` | Token to use to authorize label changes. Typically the GITHUB_TOKEN secret | `${{ github.token }}` |
 | `configuration-path` | The path to the label configuration file | `.github/labeler.yml` |
 | `sync-labels` | Whether or not to remove labels when matching files are reverted or no longer changed by the PR | `false`
 

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,8 @@ author: 'GitHub'
 inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
+    default: '${{ github.token }}'
+    required: false
   configuration-path:
     description: 'The path for the label configurations'
     default: '.github/labeler.yml'


### PR DESCRIPTION
To simplify the action, we can add the `github.token` in the default field for the `repo-token` input. This would make the action a bit less verbose for normal use. Now the action will default to `github.token` without needing an explicit definition.

Note: I don't know how to test this properly so that it'd be good if you can test whether or not it works as expected.