### PR TITLE
docs(readme): specified 'yml' syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ frontend:
 
 Create a workflow (eg: `.github/workflows/labeler.yml` see [Creating a Workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)) to utilize the labeler action with content:
 
-```
+```yml
 name: "Pull Request Labeler"
 on:
 - pull_request_target


### PR DESCRIPTION
- specified 'yml' syntax highlighting for a code block example in readme