### PR TITLE
Clarify `permissions` required to use Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ on:
 
 jobs:
   triage:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v3
@@ -110,7 +113,7 @@ Various inputs are defined in [`action.yml`](action.yml) to let you configure th
 
 | Name | Description | Default |
 | - | - | - |
-| `repo-token` | Token to use to authorize label changes. Typically the GITHUB_TOKEN secret | N/A |
+| `repo-token` | Token to use to authorize label changes. Typically the GITHUB_TOKEN secret, with `contents:read` and `pull-requests:write` access | N/A |
 | `configuration-path` | The path to the label configuration file | `.github/labeler.yml` |
 | `sync-labels` | Whether or not to remove labels when matching files are reverted or no longer changed by the PR | `false`
 


### PR DESCRIPTION
As a means to reduce the privileges provided to the job executing, we
can document what the minimal `permissions` required for the Actions'
`GITHUB_TOKEN` is.