### PR TITLE
Update default runtime to node16

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -19,10 +19,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: Setup node 14
+      - name: Setup node 16
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
       - run: npm install
       - run: npm run build
       - run: npm test

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 12 has an end of life on April 30, 2022.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12. 

This is supported on all Actions Runners v2.285.0 or later.