### PR TITLE
Provide GH Token by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,7 @@ author: 'GitHub'
 inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
+    default: ${{ github.token }}
   configuration-path:
     description: 'The path for the label configurations'
     default: '.github/labeler.yml'


### PR DESCRIPTION
With this change, users no longer need to explicitly pass a `repo-token`