### PR TITLE
@mehmetaliayhan6

### DIFF
--- a/Twitter
+++ b/Twitter
@@ -1,0 +1,1 @@
+gh repo klon eylemleri/etiketleyici


### PR DESCRIPTION
- [x] `@"This` XML file does not appear to have any style information associated with it. The document tree is shown below.

<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" version="2.0">
<channel>
<title>Washington Post</title>
<description>Washington Post News Feed</description>
<link>https://www.washingtonpost.com</link>
<atom:link href="https://www.washingtonpost.com/arcio/rss/" rel="self" type="application/rss+xml"/>
<lastBuildDate>Mon, 13 Jun 2022 17:21:36 +0000</lastBuildDate>
<ttl>1</ttl>
<sy:updatePeriod>hourly</sy:updatePeriod>
<sy:updateFrequency>1</sy:updateFrequency>
</channel>
</rss>"
 https://feeds.washingtonpost.com/rss/rss_fact-checker#:~:text=This%20XML%20file,%3C/rss%3E