### PR TITLE
Explain misconfigured workflow

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -76,11 +76,25 @@ function run() {
                     labelsToRemove.push(label);
                 }
             }
-            if (labels.length > 0) {
-                yield addLabels(client, prNumber, labels);
+            try {
+                if (labels.length > 0) {
+                    yield addLabels(client, prNumber, labels);
+                }
+                if (syncLabels && labelsToRemove.length) {
+                    yield removeLabels(client, prNumber, labelsToRemove);
+                }
             }
-            if (syncLabels && labelsToRemove.length) {
-                yield removeLabels(client, prNumber, labelsToRemove);
+            catch (error) {
+                if (error.name === 'HttpError' &&
+                    error.message === 'Resource not accessible by integration') {
+                    core.warning(`The action requires write permission to add labels to pull requests. For more information please refer to the action documentation: https://github.com/actions/labeler#permissions`, {
+                        title: `${process.env['GITHUB_ACTION_REPOSITORY']} running under '${github.context.eventName}' is misconfigured`
+                    });
+                    core.setFailed(error.message);
+                }
+                else {
+                    throw error;
+                }
             }
         }
         catch (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labeler",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Labels pull requests by files altered",
   "main": "lib/main.js",
   "scripts": {

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -50,12 +50,29 @@ export async function run() {
       }
     }
 
-    if (labels.length > 0) {
-      await addLabels(client, prNumber, labels);
-    }
+    try {
+      if (labels.length > 0) {
+        await addLabels(client, prNumber, labels);
+      }
 
-    if (syncLabels && labelsToRemove.length) {
-      await removeLabels(client, prNumber, labelsToRemove);
+      if (syncLabels && labelsToRemove.length) {
+        await removeLabels(client, prNumber, labelsToRemove);
+      }
+    } catch (error: any) {
+      if (
+        error.name === 'HttpError' &&
+        error.message === 'Resource not accessible by integration'
+      ) {
+        core.warning(
+          `The action requires write permission to add labels to pull requests. For more information please refer to the action documentation: https://github.com/actions/labeler#permissions`,
+          {
+            title: `${process.env['GITHUB_ACTION_REPOSITORY']} running under '${github.context.eventName}' is misconfigured`
+          }
+        );
+        core.setFailed(error.message);
+      } else {
+        throw error;
+      }
     }
   } catch (error: any) {
     core.error(error);


### PR DESCRIPTION
Labeler has a bunch of more or less related problems.

* it doesn't properly annotate its `action.yml`
* it confuses booleans and strings #404 
* it doesn't handle permissions errors #136
* it's actively hostile to forks (#136)

The general implementation to address this fits the outlines in https://github.com/actions/labeler/issues/136#issuecomment-1169411989


https://github.com/check-spelling/use-labeler/actions/runs/2729552526
<img width="1300" alt="image" src="https://user-images.githubusercontent.com/2119212/180685825-bda43868-8e96-4cfb-a4e4-ab04622eb107.png">

Annotations
1 error and 1 warning
❌ [label](https://github.com/check-spelling/use-labeler/runs/7492592323?check_suite_focus=true#step:2:9)
Resource not accessible by integration
⚠️ [jsoref/labeler running under 'pull_request' is misconfigured](https://github.com/check-spelling/use-labeler/runs/7492592323?check_suite_focus=true#step:2:8)
It needs `permissions: pull-requests: write` to work. Update the workflow. See https://github.com/actions/labeler/blob/6a315d4ea58951035b498eef56668feaba24489f/README.md#create-workflow

---

https://github.com/check-spelling/use-labeler/runs/7492560360?check_suite_focus=true

Run jsoref/labeler@main
Workflow is not configured to label forks, exiting

This could include an info item, but, I don't really see the point.

---
