### PR TITLE
 Add optional input for selectively opting-out of sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Various inputs are defined in [`action.yml`](action.yml) to let you configure th
 | `repo-token` | Token to use to authorize label changes. Typically the GITHUB_TOKEN secret, with `contents:read` and `pull-requests:write` access | N/A |
 | `configuration-path` | The path to the label configuration file | `.github/labeler.yml` |
 | `sync-labels` | Whether or not to remove labels when matching files are reverted or no longer changed by the PR | `false`
-
+| `sync-ignore-labels` | A comma or newline separated list of labels to ignore from the sync-labels remove operation | ""
 # Contributions
 
 Contributions are welcome! See the [Contributor's Guide](CONTRIBUTING.md).

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -102,6 +102,32 @@ describe("run", () => {
     expect(addLabelsMock).toHaveBeenCalledTimes(0);
     expect(removeLabelMock).toHaveBeenCalledTimes(0);
   });
+
+  it("(with sync-labels: true) it issues no delete calls for labels in sync-ignore-label", async () => {
+    let mockInput = {
+      "repo-token": "foo",
+      "configuration-path": "bar",
+      "sync-labels": true,
+      "sync-ignore-labels": "touched-a-pdf-file",
+    };
+
+    jest
+      .spyOn(core, "getInput")
+      .mockImplementation((name: string, ...opts) => mockInput[name]);
+
+    usingLabelerConfigYaml("only_pdfs.yml");
+    mockGitHubResponseChangedFiles("foo.txt");
+    getPullMock.mockResolvedValue(<any>{
+      data: {
+        labels: [{ name: "touched-a-pdf-file" }],
+      },
+    });
+
+    await run();
+
+    expect(addLabelsMock).toHaveBeenCalledTimes(0);
+    expect(removeLabelMock).toHaveBeenCalledTimes(0);
+  });
 });
 
 function usingLabelerConfigYaml(fixtureName: keyof typeof yamlFixtures): void {

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,10 @@ inputs:
     description: 'Whether or not to remove labels when matching files are reverted'
     default: false
     required: false
-
+  sync-ignore-labels:
+    description: >
+      A comma or newline separated list of labels to ignore from the sync-labels remove operation.
+    required: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,11 +45,13 @@ const github = __importStar(__nccwpck_require__(5438));
 const yaml = __importStar(__nccwpck_require__(1917));
 const minimatch_1 = __nccwpck_require__(3973);
 function run() {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const token = core.getInput("repo-token", { required: true });
             const configPath = core.getInput("configuration-path", { required: true });
             const syncLabels = !!core.getInput("sync-labels", { required: false });
+            const syncIgnoreLabels = getStringAsArray((_a = core.getInput("sync-ignore-labels")) !== null && _a !== void 0 ? _a : "");
             const prNumber = getPrNumber();
             if (!prNumber) {
                 console.log("Could not get pull request number from context, exiting");
@@ -71,7 +73,8 @@ function run() {
                 if (checkGlobs(changedFiles, globs)) {
                     labels.push(label);
                 }
-                else if (pullRequest.labels.find((l) => l.name === label)) {
+                else if (pullRequest.labels.find((l) => l.name === label) &&
+                    !syncIgnoreLabels.includes(label)) {
                     labelsToRemove.push(label);
                 }
             }
@@ -239,6 +242,12 @@ function removeLabels(client, prNumber, labels) {
             name: label,
         })));
     });
+}
+function getStringAsArray(str) {
+    return str
+        .split(/[\n,]+/)
+        .map((s) => s.trim())
+        .filter((x) => x !== "");
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "labeler",
       "version": "4.0.1",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
New Input: `sync-ignore-labels`
Required: No

Use Case: We would like to be able to add specific labels at PR creation that do not interact with the labeler labels. This is particularly useful for opting out of build automation that runs based on assigned labels.

Test case has been added to validate the behavior and all test cases are passing.

README.md has been updated to reflect new input.