### PR TITLE
Regenerate package-lock with latest node/npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "labeler",
       "version": "4.0.1",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This just added a "name" field to the innermost "package" entry.