### PR TITLE
Warn about the limitations of GitHub tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,24 @@ label1:
 - path/to/folder/**
 ```
 
+## Permissions
+
+In order to add labels to pull requests, the GitHub labeler action requires
+write permissions on the pull-request. However, when the action runs on a pull
+request from a forked repository, GitHub only grants read access tokens for
+pull_request events, at most. If you encounter an Error: HttpError: Resource
+not accessible by integration, it's likely due to these permission constraints.
+To resolve this issue, you can modify the `on:` section of your workflow to use
+[pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)
+instead of `pull_request` (see example [above](#create-workflow)). This change
+allows the action to have write access, because pull_request_target alters the
+[context of the
+action](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)
+and safely grants additional permissions. Refer to the [GitHub token
+permissions
+documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
+for more details about access levels and event contexts.
+
 ## Contributions
 
 Contributions are welcome! See the [Contributor's Guide](CONTRIBUTING.md).


### PR DESCRIPTION
The action will return

  Error: HttpError: Resource not accessible by integration

when triggered on a PR on a forked repository.