### PR TITLE
Update workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
 # Pull Request Labeler
 
-<p align="left">
-  <a href="https://github.com/actions/labeler/actions/workflows/basic-validation.yml">
-    <img alt="basic validation status" src="https://github.com/actions/labeler/actions/workflows/basic-validation.yml/badge.svg">
-  </a>
-  <a href="https://libraries.io/github/actions/labeler">
-    <img alt="dependencies" src="https://img.shields.io/librariesio/github/actions/labeler">
-  </a>
-</p>
+[![Basic validation](https://github.com/actions/labeler/actions/workflows/basic-validation.yml/badge.svg?branch=main)](https://github.com/actions/labeler/actions/workflows/basic-validation.yml)
 
 Automatically label new pull requests based on the paths of files being changed.
 


### PR DESCRIPTION
**Description:**
In the scope of this PR, [workflow badges](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) were updated to represent the current status of the workflows which test the action. The badge related to the `libraries.io` was removed because it's not possible to update information about action on this resource and it gives wrong information about out-of-date project's dependencies.

Use `display the rich diff` button to see the visual representation of the changes:
![image](https://user-images.githubusercontent.com/98037481/215442456-56bd363d-897b-4111-bd37-1dcdfcb2bbc0.png)

**Related issue:**
https://github.com/actions/runner-images-internal/issues/4709