### PR TITLE
Attempt to fix labeler "Server Error" problem

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -221,13 +221,22 @@ function checkMatch(changedFiles, matchConfig) {
     return true;
 }
 function addLabels(client, prNumber, labels) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
-        yield client.rest.issues.addLabels({
+        const currentLabels = ((_a = (yield client.rest.issues.listLabelsOnIssue({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
-            issue_number: prNumber,
-            labels: labels
-        });
+            issue_number: prNumber
+        }))) === null || _a === void 0 ? void 0 : _a.data.map(({ name }) => name)) || [];
+        const labelsToBeAdded = labels.filter(label => !currentLabels.includes(label));
+        if (labelsToBeAdded.length > 0) {
+            yield client.rest.issues.addLabels({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                issue_number: prNumber,
+                labels: labelsToBeAdded
+            });
+        }
     });
 }
 function removeLabels(client, prNumber, labels) {

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -234,12 +234,25 @@ async function addLabels(
   prNumber: number,
   labels: string[]
 ) {
-  await client.rest.issues.addLabels({
-    owner: github.context.repo.owner,
-    repo: github.context.repo.repo,
-    issue_number: prNumber,
-    labels: labels
-  });
+  const currentLabels =
+    (
+      await client.rest.issues.listLabelsOnIssue({
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
+        issue_number: prNumber
+      })
+    )?.data.map(({name}) => name) || [];
+  const labelsToBeAdded = labels.filter(
+    label => !currentLabels.includes(label)
+  );
+  if (labelsToBeAdded.length > 0) {
+    await client.rest.issues.addLabels({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      issue_number: prNumber,
+      labels: labelsToBeAdded
+    });
+  }
 }
 
 async function removeLabels(


### PR DESCRIPTION
**Description:**
This PR makes it possible to have labeler configuration with 51 or more labels on it, without causing `HttpError: Server Error` error.

**Related issue:**
This fixes PR #561.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.