### PR TITLE
Revert "fix: correct reading of sync-labels input."

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -51,17 +51,12 @@ describe('run', () => {
     const mockInput = {
       'repo-token': 'foo',
       'configuration-path': 'bar',
-      'sync-labels': 'true'
+      'sync-labels': true
     };
 
     jest
       .spyOn(core, 'getInput')
       .mockImplementation((name: string, ...opts) => mockInput[name]);
-    jest
-      .spyOn(core, 'getBooleanInput')
-      .mockImplementation(
-        (name: string, ...opts) => mockInput[name] === 'true'
-      );
 
     usingLabelerConfigYaml('only_pdfs.yml');
     mockGitHubResponseChangedFiles('foo.txt');
@@ -87,17 +82,12 @@ describe('run', () => {
     const mockInput = {
       'repo-token': 'foo',
       'configuration-path': 'bar',
-      'sync-labels': 'false'
+      'sync-labels': false
     };
 
     jest
       .spyOn(core, 'getInput')
       .mockImplementation((name: string, ...opts) => mockInput[name]);
-    jest
-      .spyOn(core, 'getBooleanInput')
-      .mockImplementation(
-        (name: string, ...opts) => mockInput[name] === 'true'
-      );
 
     usingLabelerConfigYaml('only_pdfs.yml');
     mockGitHubResponseChangedFiles('foo.txt');

--- a/dist/index.js
+++ b/dist/index.js
@@ -49,7 +49,7 @@ function run() {
         try {
             const token = core.getInput('repo-token');
             const configPath = core.getInput('configuration-path', { required: true });
-            const syncLabels = core.getBooleanInput('sync-labels');
+            const syncLabels = !!core.getInput('sync-labels', { required: false });
             const prNumber = getPrNumber();
             if (!prNumber) {
                 core.info('Could not get pull request number from context, exiting');

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -15,7 +15,7 @@ export async function run() {
   try {
     const token = core.getInput('repo-token');
     const configPath = core.getInput('configuration-path', {required: true});
-    const syncLabels = core.getBooleanInput('sync-labels');
+    const syncLabels = !!core.getInput('sync-labels', {required: false});
 
     const prNumber = getPrNumber();
     if (!prNumber) {


### PR DESCRIPTION
We are reverting [this PR](https://github.com/actions/labeler/pull/480) because it needs to be merged in the separate branch first