### PR TITLE
fix: correct reading of sync-labels input

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -62,12 +62,17 @@ describe('run', () => {
     const mockInput = {
       'repo-token': 'foo',
       'configuration-path': 'bar',
-      'sync-labels': true
+      'sync-labels': 'true'
     };
 
     jest
       .spyOn(core, 'getInput')
       .mockImplementation((name: string, ...opts) => mockInput[name]);
+    jest
+      .spyOn(core, 'getBooleanInput')
+      .mockImplementation(
+        (name: string, ...opts) => mockInput[name] === 'true'
+      );
 
     usingLabelerConfigYaml('only_pdfs.yml');
     mockGitHubResponseChangedFiles('foo.txt');
@@ -93,12 +98,17 @@ describe('run', () => {
     const mockInput = {
       'repo-token': 'foo',
       'configuration-path': 'bar',
-      'sync-labels': false
+      'sync-labels': 'false'
     };
 
     jest
       .spyOn(core, 'getInput')
       .mockImplementation((name: string, ...opts) => mockInput[name]);
+    jest
+      .spyOn(core, 'getBooleanInput')
+      .mockImplementation(
+        (name: string, ...opts) => mockInput[name] === 'true'
+      );
 
     usingLabelerConfigYaml('only_pdfs.yml');
     mockGitHubResponseChangedFiles('foo.txt');

--- a/dist/index.js
+++ b/dist/index.js
@@ -288,7 +288,7 @@ function run() {
         try {
             const token = core.getInput('repo-token');
             const configPath = core.getInput('configuration-path', { required: true });
-            const syncLabels = !!core.getInput('sync-labels', { required: false });
+            const syncLabels = core.getBooleanInput('sync-labels');
             const prNumber = getPrNumber();
             if (!prNumber) {
                 core.info('Could not get pull request number from context, exiting');

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -31,7 +31,7 @@ export async function run() {
   try {
     const token = core.getInput('repo-token');
     const configPath = core.getInput('configuration-path', {required: true});
-    const syncLabels = !!core.getInput('sync-labels', {required: false});
+    const syncLabels = core.getBooleanInput('sync-labels');
 
     const prNumber = getPrNumber();
     if (!prNumber) {


### PR DESCRIPTION
**Description:**
Correctly check the truth value of the `sync-labels` input. Currently, `core.getInput` always returns a string, and `!!'false'` is `true`.

This pull request is a copy of [this one](https://github.com/actions/labeler/pull/480).

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.