### PR TITLE
add action outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ label1:
 - path/to/folder/**
 ```
 
+#### Outputs
+
+| Name     | Description | Default |
+| -        | -           | - |
+| `labels` | A string containing the labels added, separated by white spaces. If no labels where added, it returns an empty string (`""`) | N/A |
+| `removed-labels` | A string containing the labels removed, separated by white spaces. If no labels where removed, it returns an empty string (`""`) | N/A |
+
 ## Permissions
 
 In order to add labels to pull requests, the GitHub labeler action requires

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,11 @@ inputs:
     description: 'Whether or not to auto-include paths starting with dot (e.g. `.github`)'
     default: false
     required: false
-
+outputs:
+  labels:
+    description: 'A string containing the labels added, separated by white spaces. If no labels where added, it returns an empty string (`""`)'
+  removed-labels:
+    description: 'A string containing the labels removed, separated by white spaces. If no labels where removed, it returns an empty string (`""`)'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -78,9 +78,11 @@ function run() {
             }
             if (labels.length > 0) {
                 yield addLabels(client, prNumber, labels);
+                core.setOutput('labels', labels.join(' '));
             }
             if (syncLabels && labelsToRemove.length) {
                 yield removeLabels(client, prNumber, labelsToRemove);
+                core.setOutput('removed-labels', labelsToRemove.join(' '));
             }
         }
         catch (error) {

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -52,10 +52,12 @@ export async function run() {
 
     if (labels.length > 0) {
       await addLabels(client, prNumber, labels);
+      core.setOutput('labels', labels.join(' '));
     }
 
     if (syncLabels && labelsToRemove.length) {
       await removeLabels(client, prNumber, labelsToRemove);
+      core.setOutput('removed-labels', labelsToRemove.join(' '));
     }
   } catch (error: any) {
     core.error(error);


### PR DESCRIPTION
**Description:**
Add two outputs to the action: `labels` and `removed-labels`. 

**Related issue:**
Closes #408 (previous PR that didn't include `labels-to-remove`)
Closes  #60 

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.