### PR TITLE
Fix double negation message typo

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -174,11 +174,11 @@ function getLabelGlobs(client, configurationPath) {
         let configurationContent;
         try {
             if (!fs_1.default.existsSync(configurationPath)) {
-                core.info(`The configuration file (path: ${configurationPath}) isn't not found locally, fetching via the api`);
+                core.info(`The configuration file (path: ${configurationPath}) was not found locally, fetching via the api`);
                 configurationContent = yield fetchContent(client, configurationPath);
             }
             else {
-                core.info(`The configuration file (path: ${configurationPath}) is found locally, reading from the file`);
+                core.info(`The configuration file (path: ${configurationPath}) was found locally, reading from the file`);
                 configurationContent = fs_1.default.readFileSync(configurationPath, {
                     encoding: 'utf8'
                 });

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -169,12 +169,12 @@ async function getLabelGlobs(
   try {
     if (!fs.existsSync(configurationPath)) {
       core.info(
-        `The configuration file (path: ${configurationPath}) isn't not found locally, fetching via the api`
+        `The configuration file (path: ${configurationPath}) was not found locally, fetching via the api`
       );
       configurationContent = await fetchContent(client, configurationPath);
     } else {
       core.info(
-        `The configuration file (path: ${configurationPath}) is found locally, reading from the file`
+        `The configuration file (path: ${configurationPath}) was found locally, reading from the file`
       );
       configurationContent = fs.readFileSync(configurationPath, {
         encoding: 'utf8'


### PR DESCRIPTION
**Description:**
Fix double negation typo on the file not found error message:
```diff
-The configuration file (path: /) isn't not found locally, fetching via the api
+The configuration file (path: /) was not found locally, fetching via the api
```

Note: I also changed the positive message for consistency, but I can revert if needed.

```diff
-The configuration file (path: /) is found locally, reading from the file
+The configuration file (path: /) was found locally, reading from the file
```

No documentation changes are required.

No tests were modified.

**Related issue:**

None

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.