### PR TITLE
Add note regarding `pull_request_target` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ permissions
 documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
 for more details about access levels and event contexts.
 
+## Notes regarding `pull_request_target`
+
+When submitting a initial pull request to a repository using the `pull_request_target` event, the labeler action will not run on that pull request because the `pull_request_target` execution runs off the base branch instead of the pull request's branch. Unfortunately this means the introduction of the labeler can not be verified during that pull request and it needs to be committed blindly. 
+
 ## Contributions
 
 Contributions are welcome! See the [Contributor's Guide](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ for more details about access levels and event contexts.
 
 ## Notes regarding `pull_request_target`
 
-When submitting a initial pull request to a repository using the `pull_request_target` event, the labeler action will not run on that pull request because the `pull_request_target` execution runs off the base branch instead of the pull request's branch. Unfortunately this means the introduction of the labeler can not be verified during that pull request and it needs to be committed blindly. 
+When submitting a initial pull request to a repository using the `pull_request_target` event, the labeler workflow will not run on that pull request because the `pull_request_target` execution runs off the base branch instead of the pull request's branch. Unfortunately this means the introduction of the labeler can not be verified during that pull request and it needs to be committed blindly. 
 
 ## Contributions
 


### PR DESCRIPTION
**Description:**
I think this is a big gotcha that should be called out in the documentation. I've been trying to debug why the workflow did not run in https://github.com/go-gitea/gitea/pull/26962 for a long time, until I finally understood the underlying issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.