### PR TITLE
Add option to never remove any labels

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Whether or not to remove labels when matching files are reverted'
     default: false
     required: false
+  remove-labels:
+    description: 'Whether or not to ever remove labels'
+    default: true
+    required: false
   dot:
     description: 'Whether or not to auto-include paths starting with dot (e.g. `.github`)'
     default: false

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -21,6 +21,7 @@ export async function run() {
     const token = core.getInput('repo-token');
     const configPath = core.getInput('configuration-path', {required: true});
     const syncLabels = !!core.getInput('sync-labels');
+    const removeLabels = !!core.getInput('remove-labels');
     const dot = core.getBooleanInput('dot');
 
     const prNumbers = getPrNumbers();
@@ -67,6 +68,12 @@ export async function run() {
           allLabels.add(label);
         } else if (syncLabels) {
           allLabels.delete(label);
+        }
+      }
+
+      if(!removeLabels){
+        for (const label of preexistingLabels){
+          allLabels.add(label);
         }
       }
 


### PR DESCRIPTION
Added "remove-labels", which if set to false, will never remove any existing labels. Useful for preserving manual user-added labels