### PR TITLE
Parse sync-labels with getBooleanInput

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -42,7 +42,7 @@ const configureInput = (
     'repo-token': string;
     'configuration-path': string;
     'sync-labels': string;
-    'dot': string;
+    dot: string;
     'pr-number': string[];
   }>
 ) => {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -41,8 +41,8 @@ const configureInput = (
   mockInput: Partial<{
     'repo-token': string;
     'configuration-path': string;
-    'sync-labels': boolean;
-    dot: boolean;
+    'sync-labels': string;
+    'dot': string;
     'pr-number': string[];
   }>
 ) => {
@@ -54,7 +54,7 @@ const configureInput = (
     .mockImplementation((name: string, ...opts) => mockInput[name]);
   jest
     .spyOn(core, 'getBooleanInput')
-    .mockImplementation((name: string, ...opts) => mockInput[name]);
+    .mockImplementation((name: string, ...opts) => mockInput[name] == 'true');
 };
 
 afterAll(() => jest.restoreAllMocks());
@@ -91,7 +91,7 @@ describe('run', () => {
   });
 
   it('(with dot: true) adds labels to PRs that match our glob patterns', async () => {
-    configureInput({dot: true});
+    configureInput({dot: 'true'});
     usingLabelerConfigYaml('only_pdfs.yml');
     mockGitHubResponseChangedFiles('.foo.pdf');
     getPullMock.mockResolvedValue(<any>{
@@ -137,7 +137,7 @@ describe('run', () => {
   });
 
   it('(with dot: true) does not add labels to PRs that do not match our glob patterns', async () => {
-    configureInput({dot: true});
+    configureInput({dot: 'true'});
     usingLabelerConfigYaml('only_pdfs.yml');
     mockGitHubResponseChangedFiles('foo.txt');
 
@@ -150,7 +150,7 @@ describe('run', () => {
     configureInput({
       'repo-token': 'foo',
       'configuration-path': 'bar',
-      'sync-labels': true
+      'sync-labels': 'true'
     });
 
     usingLabelerConfigYaml('only_pdfs.yml');
@@ -178,7 +178,7 @@ describe('run', () => {
     configureInput({
       'repo-token': 'foo',
       'configuration-path': 'bar',
-      'sync-labels': false
+      'sync-labels': 'false'
     });
 
     usingLabelerConfigYaml('only_pdfs.yml');
@@ -203,7 +203,7 @@ describe('run', () => {
     configureInput({
       'repo-token': 'foo',
       'configuration-path': 'bar',
-      'sync-labels': false
+      'sync-labels': 'false'
     });
 
     usingLabelerConfigYaml('only_pdfs.yml');

--- a/dist/index.js
+++ b/dist/index.js
@@ -56,7 +56,7 @@ function run() {
         try {
             const token = core.getInput('repo-token');
             const configPath = core.getInput('configuration-path', { required: true });
-            const syncLabels = !!core.getInput('sync-labels');
+            const syncLabels = core.getBooleanInput('sync-labels');
             const dot = core.getBooleanInput('dot');
             const prNumbers = getPrNumbers();
             if (!prNumbers.length) {

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -20,7 +20,7 @@ export async function run() {
   try {
     const token = core.getInput('repo-token');
     const configPath = core.getInput('configuration-path', {required: true});
-    const syncLabels = !!core.getInput('sync-labels');
+    const syncLabels = core.getBooleanInput('sync-labels');
     const dot = core.getBooleanInput('dot');
 
     const prNumbers = getPrNumbers();


### PR DESCRIPTION
seems to be the same issue as "dot", where it wasn't parsing the boolean input correctly. caused the labeler to delete manual labels even though it should default to sync-labels as false. Tests also weren't catching it because it uses a boolean directly instead of going through the string to boolean conversion logic

seems like this was already fixed once but somehow got reverted? https://github.com/actions/labeler/pull/574

ah, I see it was moved to v5