### PR TITLE
any-glob-all-files: combine glob outputs to match all files on all globs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+	"name": "Node.js",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,0 @@
-{
-	"name": "Node.js",
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye"
-}

--- a/__tests__/changedFiles.test.ts
+++ b/__tests__/changedFiles.test.ts
@@ -268,3 +268,21 @@ describe('checkIfAllGlobsMatchAllFiles', () => {
     });
   });
 });
+
+
+describe('check issue #423', () => {
+  const changedFiles = ['test.md', 'test.puml'];
+
+  describe('when at least one pattern matches all files', () => {
+    const globPatterns = ['*.md', '*.puml'];
+
+    it('returns true', () => {
+      const result = checkIfAnyGlobMatchesAllFiles(
+        changedFiles,
+        globPatterns,
+        false
+      );
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/__tests__/changedFiles.test.ts
+++ b/__tests__/changedFiles.test.ts
@@ -225,6 +225,19 @@ describe('checkIfAnyGlobMatchesAllFiles', () => {
     });
   });
 
+  describe('when none of the given glob patterns matched all files', () => {
+    const globPatterns = ['*.md', 'foo.txt'];
+
+    it('returns false', () => {
+      const result = checkIfAnyGlobMatchesAllFiles(
+        changedFiles,
+        globPatterns,
+        false
+      );
+      expect(result).toBe(false);
+    });
+  });
+
   describe('when at least one of the given glob patterns matched all files', () => {
     const globPatterns = ['*.md', 'bar.txt', 'foo.txt'];
 

--- a/__tests__/changedFiles.test.ts
+++ b/__tests__/changedFiles.test.ts
@@ -225,16 +225,16 @@ describe('checkIfAnyGlobMatchesAllFiles', () => {
     });
   });
 
-  describe('when none of the given glob patterns matched all files', () => {
+  describe('when at least one of the given glob patterns matched all files', () => {
     const globPatterns = ['*.md', 'bar.txt', 'foo.txt'];
 
-    it('returns false', () => {
+    it('returns true', () => {
       const result = checkIfAnyGlobMatchesAllFiles(
         changedFiles,
         globPatterns,
         false
       );
-      expect(result).toBe(false);
+      expect(result).toBe(true);
     });
   });
 });
@@ -265,24 +265,6 @@ describe('checkIfAllGlobsMatchAllFiles', () => {
         false
       );
       expect(result).toBe(false);
-    });
-  });
-});
-
-
-describe('check issue #423', () => {
-  const changedFiles = ['test.md', 'test.puml'];
-
-  describe('when at least one pattern matches all files', () => {
-    const globPatterns = ['*.md', '*.puml'];
-
-    it('returns true', () => {
-      const result = checkIfAnyGlobMatchesAllFiles(
-        changedFiles,
-        globPatterns,
-        false
-      );
-      expect(result).toBe(true);
     });
   });
 });

--- a/src/changedFiles.ts
+++ b/src/changedFiles.ts
@@ -296,33 +296,31 @@ export function checkIfAnyGlobMatchesAllFiles(
   core.debug(`    checking "any-glob-to-all-files" config patterns`);
   const matchers = globs.map(g => new Minimatch(g, {dot}));
 
+  const allMatchesFiles = new Set<string>();
+
   for (const matcher of matchers) {
-    const mismatchedFile = changedFiles.find(changedFile => {
+    const matchedFiles = changedFiles.filter(changedFile => {
       core.debug(
         `     checking "${printPattern(
           matcher
         )}" pattern against ${changedFile}`
       );
 
-      return !matcher.match(changedFile);
+      return matcher.match(changedFile);
     });
 
-    if (mismatchedFile) {
-      core.debug(
-        `     "${printPattern(
-          matcher
-        )}" pattern did not match ${mismatchedFile}`
-      );
-
-      continue;
-    }
-
-    core.debug(`    "${printPattern(matcher)}" pattern matched all files`);
-    return true;
+    matchedFiles.forEach(item => allMatchesFiles.add(item))
   }
 
-  core.debug(`    none of the patterns matched all files`);
-  return false;
+  for (const file of changedFiles) {
+    if(!allMatchesFiles.has(file)) {
+      core.debug(`    none of the patterns matched ${file}`);
+      return false;
+    }
+  }
+
+  core.debug(`    at least one pattern matched all files`);
+  return true;
 }
 
 export function checkIfAllGlobsMatchAllFiles(


### PR DESCRIPTION
checkout the discussion at https://github.com/actions/labeler/issues/423

there is currently no way to apply the "CI" label with the following rule

```any-glob-all-files: [Jenkinsfile, .github/**]```

when a PR which changes *both* Jenkinsfile and github actions files

essentially, this test fails, which to me makes "any glob matches all files" extremely confusing.
```
describe('check issue #423', () => {
  const changedFiles = ['test.md', 'test.puml'];

  describe('when at least one pattern matches all files', () => {
    const globPatterns = ['*.md', '*.puml'];

    it('returns true', () => {
      const result = checkIfAnyGlobMatchesAllFiles(
        changedFiles,
        globPatterns,
        false
      );
      expect(result).toBe(true);
    });
  });
});
```

perhaps this behavior should be moved to another rule, since it also breaks this potential use case: https://github.com/actions/labeler/blob/8558fd74291d67161a8a78ce36a881fa63b766a9/__tests__/changedFiles.test.ts#L228C3-L239C6