### PR TITLE
Add test and documentation for any-glob-to-all-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The fields are defined as follows:
   - `head-branch`: match regexps against the head branch name
   - `changed-files`: match glob patterns against the changed paths
     - `any-glob-to-any-file`: ANY glob must match against ANY changed file
-    - `any-glob-to-all-files`: ANY glob must match against ALL changed files
+    - `any-glob-to-all-files`: ANY SINGLE glob must match against ALL changed files
     - `all-globs-to-any-file`: ALL globs must match against ANY changed file
     - `all-globs-to-all-files`: ALL globs must match against ALL changed files
 
@@ -128,7 +128,19 @@ Documentation:
 # Add 'Documentation' label to any change to .md files within the entire repository 
 Documentation:
 - changed-files:
-  - any-glob-to-any-file: '**/*.md'
+  - any-glob-to-any-file:
+    - '*.md'
+    - '**/*.md'
+
+# Add 'one-resolution' label to any change touching only files in a single directory
+one-resolution:
+- changed-files:
+  - any-glob-to-all-files: ['default/*', 'hicolor/*', 'large/*', 'locolor/*', 'mini/*']
+
+# Add 'Audio' label to any change touching only audio files in subdirectories
+Audio:
+- changed-files:
+  - any-glob-to-all-files: '{**/*.mp3,**/*.wav,**/*.ogg,**/*.flac}'
 
 # Add 'source' label to any change to src files within the source dir EXCEPT for the docs sub-folder
 source:

--- a/__tests__/changedFiles.test.ts
+++ b/__tests__/changedFiles.test.ts
@@ -211,13 +211,27 @@ describe('checkIfAllGlobsMatchAnyFile', () => {
 
 describe('checkIfAnyGlobMatchesAllFiles', () => {
   const changedFiles = ['foo.txt', 'bar.txt'];
+  const changedFiles2 = ['foo.txt', 'bar.txt', 'baz.md'];
 
-  describe('when any given glob pattern matched all files', () => {
+  describe('when any single glob pattern matched all files', () => {
     const globPatterns = ['*.md', '*.txt'];
 
     it('returns true', () => {
       const result = checkIfAnyGlobMatchesAllFiles(
         changedFiles,
+        globPatterns,
+        false
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when any of the given glob patterns in braces match all files', () => {
+    const globPatterns = ['{*.md,*.txt}', '*.mp3'];
+
+    it('returns true', () => {
+      const result = checkIfAnyGlobMatchesAllFiles(
+        changedFiles2,
         globPatterns,
         false
       );


### PR DESCRIPTION
This test verifies that the glob brace syntax will match any glob
against all files. Document that any-glob-to-all-files means any single
glob. This reduces the ambiguity that caused #731 and other issues to be
opened. Also, fix an any-glob-to-any-file example so it actually matches
within the entire repository.