### PR TITLE
docs: use more consistent and accurate glob for ignoring subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ source:
 - all:
   - changed-files:
     - any-glob-to-any-file: 'src/**/*'
-    - all-globs-to-all-files: '!src/docs/*'
+    - all-globs-to-all-files: '!src/docs/**/*'
 
 # Add 'feature' label to any PR where the head branch name starts with `feature` or has a `feature` section in the name
 feature:


### PR DESCRIPTION
**Description:**
This PR updates the readme to cover this use case a bit more accurately.

Currently, in the example touching files in `/src/docs/some/subfolder/file.txt` would still add the `source` label. This is probably not the behaviour most people are interested in, and is a bit different from what the comment says:
> Add 'source' label to any change to src files within the source dir EXCEPT for the docs sub-folder

By switching to `**/*` we can recursively match files inside the `docs` folder, not just files directly in `docs`.

**Related issue:**
-

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.