### PR TITLE
Update broken Creating a Workflow file section url in the README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ release:
 
 ### Create Workflow
 
-Create a workflow (e.g. `.github/workflows/labeler.yml` see [Creating a Workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)) to utilize the labeler action with content:
+Create a workflow (e.g. `.github/workflows/labeler.yml` see [Creating a Workflow file](https://docs.github.com/en/actions/writing-workflows/quickstart#creating-your-first-workflow)) to utilize the labeler action with content:
 
 ```yml
 name: "Pull Request Labeler"


### PR DESCRIPTION
**Description:**
It was recently brought into notice by one of the user that the reference link to  **Creating a Workflow file** section is broken in the README file. Following PR has the reference link fixed to the above mentioned section, which will navigate to appropraite documentation to help a user with creating a work flow file.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.