### PR TITLE
feat: add pr title matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The base match object is defined as:
   - all-globs-to-all-files: ['list', 'of', 'globs']
 - base-branch: ['list', 'of', 'regexps']
 - head-branch: ['list', 'of', 'regexps']
+- title: ['list', 'of', 'regexps']
 ```
 
 There are two top-level keys, `any` and `all`, which both accept the same configuration options:
@@ -49,6 +50,7 @@ There are two top-level keys, `any` and `all`, which both accept the same config
     - all-globs-to-all-files: ['list', 'of', 'globs']
   - base-branch: ['list', 'of', 'regexps']
   - head-branch: ['list', 'of', 'regexps']
+  - title: ['list', 'of', 'regexps']
 - all:
   - changed-files:
     - any-glob-to-any-file: ['list', 'of', 'globs']
@@ -57,6 +59,7 @@ There are two top-level keys, `any` and `all`, which both accept the same config
     - all-globs-to-all-files: ['list', 'of', 'globs']
   - base-branch: ['list', 'of', 'regexps']
   - head-branch: ['list', 'of', 'regexps']
+  - title: ['list', 'of', 'regexps']
 ```
 
 From a boolean logic perspective, top-level match objects, and options within `all` are `AND`-ed together and individual match rules within the `any` object are `OR`-ed.
@@ -65,13 +68,14 @@ One or all fields can be provided for fine-grained matching.
 The fields are defined as follows:
 - `all`: ALL of the provided options must match for the label to be applied
 - `any`: if ANY of the provided options match then the label will be applied
-  - `base-branch`: match regexps against the base branch name
-  - `head-branch`: match regexps against the head branch name
   - `changed-files`: match glob patterns against the changed paths
     - `any-glob-to-any-file`: ANY glob must match against ANY changed file
     - `any-glob-to-all-files`: ANY glob must match against ALL changed files
     - `all-globs-to-any-file`: ALL globs must match against ANY changed file
     - `all-globs-to-all-files`: ALL globs must match against ALL changed files
+  - `base-branch`: match regexps against the base branch name
+  - `head-branch`: match regexps against the head branch name
+  - `title`: match regexps against the pull request title
 
 If a base option is provided without a top-level key, then it will default to `any`. More specifically, the following two configurations are equivalent:
 ```yml
@@ -144,6 +148,19 @@ feature:
 # Add 'release' label to any PR that is opened against the `main` branch
 release:
  - base-branch: 'main'
+
+# Add 'chore' label to any PR where the title starts with `chore`
+chore:
+ - title: '^chore'
+
+# Add 'ci' label to any PR where the title starts with `ci` or `build`:
+ci:
+ - title: ['^ci', '^build']
+
+# Add 'web' label to any PR where the title includes conventional commits optional scope
+web:
+ - title: '^\w+\(web\):'
+
 ```
 
 ### Create Workflow

--- a/__mocks__/@actions/github.ts
+++ b/__mocks__/@actions/github.ts
@@ -7,7 +7,8 @@ export const context = {
       },
       base: {
         ref: 'base-branch-name'
-      }
+      },
+      title: 'pr-title'
     }
   },
   repo: {

--- a/__tests__/title.test.ts
+++ b/__tests__/title.test.ts
@@ -1,0 +1,143 @@
+import {
+  getTitle,
+  checkAnyTitle,
+  checkAllTitle,
+  toTitleMatchConfig,
+  TitleMatchConfig
+} from '../src/title';
+import * as github from '@actions/github';
+
+jest.mock('@actions/core');
+jest.mock('@actions/github');
+
+describe('getTitle', () => {
+  describe('when the pull requests title is requested', () => {
+    it('returns the title', () => {
+      const result = getTitle();
+      expect(result).toEqual('pr-title');
+    });
+  });
+});
+
+describe('checkAllTitle', () => {
+  beforeEach(() => {
+    github.context.payload.pull_request!.title = 'type(scope): description';
+  });
+
+  describe('when a single pattern is provided', () => {
+    describe('and the pattern matches the title', () => {
+      it('returns true', () => {
+        const result = checkAllTitle(['^type']);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('and the pattern does not match the title', () => {
+      it('returns false', () => {
+        const result = checkAllTitle(['^feature/']);
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('when multiple patterns are provided', () => {
+    describe('and not all patterns matched', () => {
+      it('returns false', () => {
+        const result = checkAllTitle(['^type', '^test']);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('and all patterns match', () => {
+      it('returns true', () => {
+        const result = checkAllTitle(['^type', '^\\w+\\(scope\\):']);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('and no patterns match', () => {
+      it('returns false', () => {
+        const result = checkAllTitle(['^feature', 'test$']);
+        expect(result).toBe(false);
+      });
+    });
+  });
+});
+
+describe('checkAnyTitle', () => {
+  beforeEach(() => {
+    github.context.payload.pull_request!.title = 'type(scope): description';
+  });
+
+  describe('when a single pattern is provided', () => {
+    describe('and the pattern matches the title', () => {
+      it('returns true', () => {
+        const result = checkAnyTitle(['^type']);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('and the pattern does not match the title', () => {
+      it('returns false', () => {
+        const result = checkAnyTitle(['^test']);
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('when multiple patterns are provided', () => {
+    describe('and at least one pattern matches', () => {
+      it('returns true', () => {
+        const result = checkAnyTitle(['^type', '^test']);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('and all patterns match', () => {
+      it('returns true', () => {
+        const result = checkAnyTitle(['^type', '^\\w+\\(scope\\):']);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('and no patterns match', () => {
+      it('returns false', () => {
+        const result = checkAllTitle(['^feature', 'test$']);
+        expect(result).toBe(false);
+      });
+    });
+  });
+});
+
+describe('toTitleMatchConfig', () => {
+  describe('when there are no title keys in the config', () => {
+    const config = {'changed-files': [{any: ['testing']}]};
+
+    it('returns an empty object', () => {
+      const result = toTitleMatchConfig(config);
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('when the config contains a title option', () => {
+    const config = {title: ['testing']};
+
+    it('sets title in the matchConfig', () => {
+      const result = toTitleMatchConfig(config);
+      expect(result).toEqual<TitleMatchConfig>({
+        title: ['testing']
+      });
+    });
+
+    describe('and the matching option is a string', () => {
+      const stringConfig = {title: 'testing'};
+
+      it('sets title in the matchConfig', () => {
+        const result = toTitleMatchConfig(stringConfig);
+        expect(result).toEqual<TitleMatchConfig>({
+          title: ['testing']
+        });
+      });
+    });
+  });
+});

--- a/src/api/get-label-configs.ts
+++ b/src/api/get-label-configs.ts
@@ -11,14 +11,23 @@ import {
 
 import {toBranchMatchConfig, BranchMatchConfig} from '../branch';
 
+import {toTitleMatchConfig, TitleMatchConfig} from '../title';
+
 export interface MatchConfig {
   all?: BaseMatchConfig[];
   any?: BaseMatchConfig[];
 }
 
-export type BaseMatchConfig = BranchMatchConfig & ChangedFilesMatchConfig;
+export type BaseMatchConfig = BranchMatchConfig &
+  ChangedFilesMatchConfig &
+  TitleMatchConfig;
 
-const ALLOWED_CONFIG_KEYS = ['changed-files', 'head-branch', 'base-branch'];
+const ALLOWED_CONFIG_KEYS = [
+  'changed-files',
+  'head-branch',
+  'base-branch',
+  'title'
+];
 
 export const getLabelConfigs = (
   client: ClientType,
@@ -118,9 +127,11 @@ export function getLabelConfigMapFromObject(
 export function toMatchConfig(config: any): BaseMatchConfig {
   const changedFilesConfig = toChangedFilesMatchConfig(config);
   const branchConfig = toBranchMatchConfig(config);
+  const titleConfig = toTitleMatchConfig(config);
 
   return {
     ...changedFilesConfig,
-    ...branchConfig
+    ...branchConfig,
+    ...titleConfig
   };
 }

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -11,6 +11,8 @@ import {checkAllChangedFiles, checkAnyChangedFiles} from './changedFiles';
 
 import {checkAnyBranch, checkAllBranch} from './branch';
 
+import {checkAnyTitle, checkAllTitle} from './title';
+
 type ClientType = ReturnType<typeof github.getOctokit>;
 
 // GitHub Issues cannot have more than 100 labels
@@ -173,6 +175,13 @@ export function checkAny(
         return true;
       }
     }
+
+    if (matchConfig.title) {
+      if (checkAnyTitle(matchConfig.title)) {
+        core.debug(`  "any" patterns matched`);
+        return true;
+      }
+    }
   }
 
   core.debug(`  "any" patterns did not match any configs`);
@@ -216,6 +225,13 @@ export function checkAll(
 
     if (matchConfig.headBranch) {
       if (!checkAllBranch(matchConfig.headBranch, 'head')) {
+        core.debug(`  "all" patterns did not match`);
+        return false;
+      }
+    }
+
+    if (matchConfig.title) {
+      if (!checkAllTitle(matchConfig.title)) {
         core.debug(`  "all" patterns did not match`);
         return false;
       }

--- a/src/title.ts
+++ b/src/title.ts
@@ -1,0 +1,83 @@
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+
+export interface TitleMatchConfig {
+  title?: string[];
+}
+
+export function toTitleMatchConfig(config: any): TitleMatchConfig {
+  if (!config['title']) {
+    return {};
+  }
+
+  const titleConfig = {
+    title: config['title']
+  };
+
+  if (typeof titleConfig.title === 'string') {
+    titleConfig.title = [titleConfig.title];
+  }
+
+  return titleConfig;
+}
+
+export function getTitle(): string | undefined {
+  const pullRequest = github.context.payload.pull_request;
+
+  if (!pullRequest) {
+    return undefined;
+  }
+
+  return pullRequest.title;
+}
+
+export function checkAnyTitle(regexps: string[]): boolean {
+  const title = getTitle();
+  if (!title) {
+    core.debug(`    cannot fetch title from the pull request`);
+    return false;
+  }
+
+  core.debug(`    checking "title" pattern against ${title}`);
+  const matchers = regexps.map(regexp => new RegExp(regexp));
+  for (const matcher of matchers) {
+    if (matchTitlePattern(matcher, title)) {
+      core.debug(`    "title" patterns matched against ${title}`);
+      return true;
+    }
+  }
+
+  core.debug(`  "title" patterns did not match against ${title}`);
+  return false;
+}
+
+export function checkAllTitle(regexps: string[]): boolean {
+  const title = getTitle();
+  if (!title) {
+    core.debug(`   cannot fetch title from the pull request`);
+    return false;
+  }
+
+  core.debug(`   checking "title" pattern against ${title}`);
+  const matchers = regexps.map(regexp => new RegExp(regexp));
+  for (const matcher of matchers) {
+    if (!matchTitlePattern(matcher, title)) {
+      core.debug(`   "title" patterns did not match against ${title}`);
+      return false;
+    }
+  }
+
+  core.debug(`   "title" patterns matched against ${title}`);
+  return true;
+}
+
+function matchTitlePattern(matcher: RegExp, title: string): boolean {
+  core.debug(`    - ${matcher}`);
+  if (matcher.test(title)) {
+    core.debug(`    "title" pattern matched`);
+    return true;
+  }
+
+  core.debug(`    ${matcher} did not match`);
+  return false;
+}


### PR DESCRIPTION
**Description:**
Adds an additional match configuration for any and all for matching PR titles.

If this PR is acceptable I can also add matching PR body content matching in the same way.


**Related issue:**

supersedes, closes #688
supersedes, closes #109 
refs #55 
closes #809 

**Check list:**
- [X] Mark if documentation changes are required. (Included)
- [X] Mark if tests were added or updated to cover the changes.