### PR TITLE
feat: Get the branch name using the pull request response

### DIFF
--- a/__tests__/branch.test.ts
+++ b/__tests__/branch.test.ts
@@ -5,48 +5,55 @@ import {
   toBranchMatchConfig,
   BranchMatchConfig
 } from '../src/branch';
-import * as github from '@actions/github';
 
 jest.mock('@actions/core');
-jest.mock('@actions/github');
 
 describe('getBranchName', () => {
+  const prData = {
+    base: {
+      ref: 'base-branch-name'
+    },
+    head: {
+      ref: 'head-branch-name'
+    }
+  };
+
   describe('when the pull requests base branch is requested', () => {
     it('returns the base branch name', () => {
-      const result = getBranchName('base');
+      const result = getBranchName(prData, 'base');
       expect(result).toEqual('base-branch-name');
     });
   });
 
   describe('when the pull requests head branch is requested', () => {
     it('returns the head branch name', () => {
-      const result = getBranchName('head');
+      const result = getBranchName(prData, 'head');
       expect(result).toEqual('head-branch-name');
     });
   });
 });
 
 describe('checkAllBranch', () => {
-  beforeEach(() => {
-    github.context.payload.pull_request!.head = {
-      ref: 'test/feature/123'
-    };
-    github.context.payload.pull_request!.base = {
+  const prData = {
+    base: {
       ref: 'main'
-    };
-  });
+    },
+    head: {
+      ref: 'test/feature/123'
+    }
+  };
 
   describe('when a single pattern is provided', () => {
     describe('and the pattern matches the head branch', () => {
       it('returns true', () => {
-        const result = checkAllBranch(['^test'], 'head');
+        const result = checkAllBranch(prData, ['^test'], 'head');
         expect(result).toBe(true);
       });
     });
 
     describe('and the pattern does not match the head branch', () => {
       it('returns false', () => {
-        const result = checkAllBranch(['^feature/'], 'head');
+        const result = checkAllBranch(prData, ['^feature/'], 'head');
         expect(result).toBe(false);
       });
     });
@@ -55,21 +62,21 @@ describe('checkAllBranch', () => {
   describe('when multiple patterns are provided', () => {
     describe('and not all patterns matched', () => {
       it('returns false', () => {
-        const result = checkAllBranch(['^test/', '^feature/'], 'head');
+        const result = checkAllBranch(prData, ['^test/', '^feature/'], 'head');
         expect(result).toBe(false);
       });
     });
 
     describe('and all patterns match', () => {
       it('returns true', () => {
-        const result = checkAllBranch(['^test/', '/feature/'], 'head');
+        const result = checkAllBranch(prData, ['^test/', '/feature/'], 'head');
         expect(result).toBe(true);
       });
     });
 
     describe('and no patterns match', () => {
       it('returns false', () => {
-        const result = checkAllBranch(['^feature/', '/test$'], 'head');
+        const result = checkAllBranch(prData, ['^feature/', '/test$'], 'head');
         expect(result).toBe(false);
       });
     });
@@ -78,7 +85,7 @@ describe('checkAllBranch', () => {
   describe('when the branch to check is specified as the base branch', () => {
     describe('and the pattern matches the base branch', () => {
       it('returns true', () => {
-        const result = checkAllBranch(['^main$'], 'base');
+        const result = checkAllBranch(prData, ['^main$'], 'base');
         expect(result).toBe(true);
       });
     });
@@ -86,26 +93,26 @@ describe('checkAllBranch', () => {
 });
 
 describe('checkAnyBranch', () => {
-  beforeEach(() => {
-    github.context.payload.pull_request!.head = {
-      ref: 'test/feature/123'
-    };
-    github.context.payload.pull_request!.base = {
+  const prData = {
+    base: {
       ref: 'main'
-    };
-  });
+    },
+    head: {
+      ref: 'test/feature/123'
+    }
+  };
 
   describe('when a single pattern is provided', () => {
     describe('and the pattern matches the head branch', () => {
       it('returns true', () => {
-        const result = checkAnyBranch(['^test'], 'head');
+        const result = checkAnyBranch(prData, ['^test'], 'head');
         expect(result).toBe(true);
       });
     });
 
     describe('and the pattern does not match the head branch', () => {
       it('returns false', () => {
-        const result = checkAnyBranch(['^feature/'], 'head');
+        const result = checkAnyBranch(prData, ['^feature/'], 'head');
         expect(result).toBe(false);
       });
     });
@@ -114,21 +121,21 @@ describe('checkAnyBranch', () => {
   describe('when multiple patterns are provided', () => {
     describe('and at least one pattern matches', () => {
       it('returns true', () => {
-        const result = checkAnyBranch(['^test/', '^feature/'], 'head');
+        const result = checkAnyBranch(prData, ['^test/', '^feature/'], 'head');
         expect(result).toBe(true);
       });
     });
 
     describe('and all patterns match', () => {
       it('returns true', () => {
-        const result = checkAnyBranch(['^test/', '/feature/'], 'head');
+        const result = checkAnyBranch(prData, ['^test/', '/feature/'], 'head');
         expect(result).toBe(true);
       });
     });
 
     describe('and no patterns match', () => {
       it('returns false', () => {
-        const result = checkAnyBranch(['^feature/', '/test$'], 'head');
+        const result = checkAnyBranch(prData, ['^feature/', '/test$'], 'head');
         expect(result).toBe(false);
       });
     });
@@ -137,7 +144,7 @@ describe('checkAnyBranch', () => {
   describe('when the branch to check is specified as the base branch', () => {
     describe('and the pattern matches the base branch', () => {
       it('returns true', () => {
-        const result = checkAnyBranch(['^main$'], 'base');
+        const result = checkAnyBranch(prData, ['^main$'], 'base');
         expect(result).toBe(true);
       });
     });

--- a/__tests__/labeler.test.ts
+++ b/__tests__/labeler.test.ts
@@ -88,6 +88,15 @@ describe('toMatchConfig', () => {
 });
 
 describe('checkMatchConfigs', () => {
+  const prData = {
+    base: {
+      ref: 'base-branch-name'
+    },
+    head: {
+      ref: 'head-branch-name'
+    }
+  };
+
   describe('when a single match config is provided', () => {
     const matchConfig: MatchConfig[] = [
       {any: [{changedFiles: [{anyGlobToAnyFile: ['*.txt']}]}]}
@@ -95,14 +104,14 @@ describe('checkMatchConfigs', () => {
 
     it('returns true when our pattern does match changed files', () => {
       const changedFiles = ['foo.txt', 'bar.txt'];
-      const result = checkMatchConfigs(changedFiles, matchConfig, false);
+      const result = checkMatchConfigs(prData, changedFiles, matchConfig, false);
 
       expect(result).toBeTruthy();
     });
 
     it('returns false when our pattern does not match changed files', () => {
       const changedFiles = ['foo.docx'];
-      const result = checkMatchConfigs(changedFiles, matchConfig, false);
+      const result = checkMatchConfigs(prData, changedFiles, matchConfig, false);
 
       expect(result).toBeFalsy();
     });
@@ -118,20 +127,20 @@ describe('checkMatchConfigs', () => {
       ];
       const changedFiles = ['foo.txt', 'bar.txt'];
 
-      const result = checkMatchConfigs(changedFiles, matchConfig, false);
+      const result = checkMatchConfigs(prData, changedFiles, matchConfig, false);
       expect(result).toBe(true);
     });
 
     it('returns false for a file starting with dot if `dot` option is false', () => {
       const changedFiles = ['.foo.txt'];
-      const result = checkMatchConfigs(changedFiles, matchConfig, false);
+      const result = checkMatchConfigs(prData, changedFiles, matchConfig, false);
 
       expect(result).toBeFalsy();
     });
 
     it('returns true for a file starting with dot if `dot` option is true', () => {
       const changedFiles = ['.foo.txt'];
-      const result = checkMatchConfigs(changedFiles, matchConfig, true);
+      const result = checkMatchConfigs(prData, changedFiles, matchConfig, true);
 
       expect(result).toBeTruthy();
     });
@@ -145,7 +154,7 @@ describe('checkMatchConfigs', () => {
     const changedFiles = ['foo.txt', 'bar.md'];
 
     it('returns false when only one config matches', () => {
-      const result = checkMatchConfigs(changedFiles, matchConfig, false);
+      const result = checkMatchConfigs(prData, changedFiles, matchConfig, false);
       expect(result).toBe(false);
     });
 
@@ -154,7 +163,7 @@ describe('checkMatchConfigs', () => {
         {any: [{changedFiles: [{anyGlobToAnyFile: ['*.txt']}]}]},
         {any: [{headBranch: ['head-branch']}]}
       ];
-      const result = checkMatchConfigs(changedFiles, matchConfig, false);
+      const result = checkMatchConfigs(prData, changedFiles, matchConfig, false);
       expect(result).toBe(true);
     });
   });

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -5,7 +5,6 @@ import path from 'path';
 import fs from 'fs';
 
 jest.mock('@actions/core');
-jest.mock('@actions/github');
 
 const gh = github.getOctokit('_');
 const setLabelsMock = jest.spyOn(gh.rest.issues, 'setLabels');
@@ -69,7 +68,13 @@ describe('run', () => {
     mockGitHubResponseChangedFiles('foo.pdf');
     getPullMock.mockResolvedValue(<any>{
       data: {
-        labels: []
+        labels: [],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'head-branch-name'
+        }
       }
     });
 
@@ -99,7 +104,13 @@ describe('run', () => {
     mockGitHubResponseChangedFiles('.foo.pdf');
     getPullMock.mockResolvedValue(<any>{
       data: {
-        labels: []
+        labels: [],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'head-branch-name'
+        }
       }
     });
 
@@ -128,7 +139,13 @@ describe('run', () => {
     mockGitHubResponseChangedFiles('.foo.pdf');
     getPullMock.mockResolvedValue(<any>{
       data: {
-        labels: []
+        labels: [],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'head-branch-name'
+        }
       }
     });
 
@@ -159,7 +176,17 @@ describe('run', () => {
 
   it('adds labels based on the branch names that match the regexp pattern', async () => {
     configureInput({});
-    github.context.payload.pull_request!.head = {ref: 'test/testing-time'};
+    getPullMock.mockResolvedValue(<any>{
+      data: {
+        labels: [],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'test/testing-time'
+        }
+      }
+    });
     usingLabelerConfigYaml('branches.yml');
     await run();
 
@@ -177,9 +204,17 @@ describe('run', () => {
 
   it('adds multiple labels based on branch names that match different regexp patterns', async () => {
     configureInput({});
-    github.context.payload.pull_request!.head = {
-      ref: 'test/feature/123'
-    };
+    getPullMock.mockResolvedValue(<any>{
+      data: {
+        labels: [],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'test/feature/123'
+        }
+      }
+    });
     usingLabelerConfigYaml('branches.yml');
     await run();
 
@@ -203,7 +238,17 @@ describe('run', () => {
 
   it('can support multiple branches by batching', async () => {
     configureInput({});
-    github.context.payload.pull_request!.head = {ref: 'fix/123'};
+    getPullMock.mockResolvedValue(<any>{
+      data: {
+        labels: [],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'fix/123'
+        }
+      }
+    });
     usingLabelerConfigYaml('branches.yml');
     await run();
 
@@ -221,7 +266,17 @@ describe('run', () => {
 
   it('can support multiple branches by providing an array', async () => {
     configureInput({});
-    github.context.payload.pull_request!.head = {ref: 'array/123'};
+    getPullMock.mockResolvedValue(<any>{
+      data: {
+        labels: [],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'array/123'
+        }
+      }
+    });
     usingLabelerConfigYaml('branches.yml');
     await run();
 
@@ -275,7 +330,13 @@ describe('run', () => {
     mockGitHubResponseChangedFiles('foo.txt');
     getPullMock.mockResolvedValue(<any>{
       data: {
-        labels: [{name: 'touched-a-pdf-file'}, {name: 'manually-added'}]
+        labels: [{name: 'touched-a-pdf-file'}, {name: 'manually-added'}],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'head-branch-name'
+        }
       }
     });
 
@@ -304,7 +365,13 @@ describe('run', () => {
     mockGitHubResponseChangedFiles('foo.txt');
     getPullMock.mockResolvedValue(<any>{
       data: {
-        labels: [{name: 'touched-a-pdf-file'}, {name: 'manually-added'}]
+        labels: [{name: 'touched-a-pdf-file'}, {name: 'manually-added'}],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'head-branch-name'
+        }
       }
     });
 
@@ -333,7 +400,13 @@ describe('run', () => {
     }));
     getPullMock.mockResolvedValue(<any>{
       data: {
-        labels: existingLabels
+        labels: existingLabels,
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'head-branch-name'
+        }
       }
     });
 
@@ -363,7 +436,13 @@ describe('run', () => {
 
     getPullMock.mockResolvedValue(<any>{
       data: {
-        labels: [{name: 'manually-added'}]
+        labels: [{name: 'manually-added'}],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'head-branch-name'
+        }
       }
     });
 
@@ -397,13 +476,25 @@ describe('run', () => {
 
     getPullMock.mockResolvedValueOnce(<any>{
       data: {
-        labels: [{name: 'manually-added'}]
+        labels: [{name: 'manually-added'}],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'head-branch-name'
+        }
       }
     });
 
     getPullMock.mockResolvedValueOnce(<any>{
       data: {
-        labels: []
+        labels: [],
+        base: {
+          ref: 'base-branch-name'
+        },
+        head: {
+          ref: 'head-branch-name'
+        }
       }
     });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -505,7 +505,6 @@ exports.getBranchName = getBranchName;
 exports.checkAnyBranch = checkAnyBranch;
 exports.checkAllBranch = checkAllBranch;
 const core = __importStar(__nccwpck_require__(7484));
-const github = __importStar(__nccwpck_require__(3228));
 function toBranchMatchConfig(config) {
     if (!config['head-branch'] && !config['base-branch']) {
         return {};
@@ -521,21 +520,17 @@ function toBranchMatchConfig(config) {
     }
     return branchConfig;
 }
-function getBranchName(branchBase) {
+function getBranchName(prData, branchBase) {
     var _a, _b;
-    const pullRequest = github.context.payload.pull_request;
-    if (!pullRequest) {
-        return undefined;
-    }
     if (branchBase === 'base') {
-        return (_a = pullRequest.base) === null || _a === void 0 ? void 0 : _a.ref;
+        return (_a = prData.base) === null || _a === void 0 ? void 0 : _a.ref;
     }
     else {
-        return (_b = pullRequest.head) === null || _b === void 0 ? void 0 : _b.ref;
+        return (_b = prData.head) === null || _b === void 0 ? void 0 : _b.ref;
     }
 }
-function checkAnyBranch(regexps, branchBase) {
-    const branchName = getBranchName(branchBase);
+function checkAnyBranch(prData, regexps, branchBase) {
+    const branchName = getBranchName(prData, branchBase);
     if (!branchName) {
         core.debug(`   no branch name`);
         return false;
@@ -551,8 +546,8 @@ function checkAnyBranch(regexps, branchBase) {
     core.debug(`   "branch" patterns did not match against ${branchName}`);
     return false;
 }
-function checkAllBranch(regexps, branchBase) {
-    const branchName = getBranchName(branchBase);
+function checkAllBranch(prData, regexps, branchBase) {
+    const branchName = getBranchName(prData, branchBase);
     if (!branchName) {
         core.debug(`   cannot fetch branch name from the pull request`);
         return false;
@@ -1066,7 +1061,7 @@ function labeler() {
                 const allLabels = new Set(preexistingLabels);
                 for (const [label, configs] of labelConfigs.entries()) {
                     core.debug(`processing ${label}`);
-                    if (checkMatchConfigs(pullRequest.changedFiles, configs, dot)) {
+                    if (checkMatchConfigs(pullRequest.data, pullRequest.changedFiles, configs, dot)) {
                         allLabels.add(label);
                     }
                     else if (syncLabels) {
@@ -1109,34 +1104,34 @@ function labeler() {
         }
     });
 }
-function checkMatchConfigs(changedFiles, matchConfigs, dot) {
+function checkMatchConfigs(prData, changedFiles, matchConfigs, dot) {
     for (const config of matchConfigs) {
         core.debug(` checking config ${JSON.stringify(config)}`);
-        if (!checkMatch(changedFiles, config, dot)) {
+        if (!checkMatch(prData, changedFiles, config, dot)) {
             return false;
         }
     }
     return true;
 }
-function checkMatch(changedFiles, matchConfig, dot) {
+function checkMatch(prData, changedFiles, matchConfig, dot) {
     if (!Object.keys(matchConfig).length) {
         core.debug(`  no "any" or "all" patterns to check`);
         return false;
     }
     if (matchConfig.all) {
-        if (!checkAll(matchConfig.all, changedFiles, dot)) {
+        if (!checkAll(matchConfig.all, prData, changedFiles, dot)) {
             return false;
         }
     }
     if (matchConfig.any) {
-        if (!checkAny(matchConfig.any, changedFiles, dot)) {
+        if (!checkAny(matchConfig.any, prData, changedFiles, dot)) {
             return false;
         }
     }
     return true;
 }
 // equivalent to "Array.some()" but expanded for debugging and clarity
-function checkAny(matchConfigs, changedFiles, dot) {
+function checkAny(matchConfigs, prData, changedFiles, dot) {
     core.debug(`  checking "any" patterns`);
     if (!matchConfigs.length ||
         !matchConfigs.some(configOption => Object.keys(configOption).length)) {
@@ -1145,7 +1140,7 @@ function checkAny(matchConfigs, changedFiles, dot) {
     }
     for (const matchConfig of matchConfigs) {
         if (matchConfig.baseBranch) {
-            if ((0, branch_1.checkAnyBranch)(matchConfig.baseBranch, 'base')) {
+            if ((0, branch_1.checkAnyBranch)(prData, matchConfig.baseBranch, 'base')) {
                 core.debug(`  "any" patterns matched`);
                 return true;
             }
@@ -1157,7 +1152,7 @@ function checkAny(matchConfigs, changedFiles, dot) {
             }
         }
         if (matchConfig.headBranch) {
-            if ((0, branch_1.checkAnyBranch)(matchConfig.headBranch, 'head')) {
+            if ((0, branch_1.checkAnyBranch)(prData, matchConfig.headBranch, 'head')) {
                 core.debug(`  "any" patterns matched`);
                 return true;
             }
@@ -1167,7 +1162,7 @@ function checkAny(matchConfigs, changedFiles, dot) {
     return false;
 }
 // equivalent to "Array.every()" but expanded for debugging and clarity
-function checkAll(matchConfigs, changedFiles, dot) {
+function checkAll(matchConfigs, prData, changedFiles, dot) {
     core.debug(`  checking "all" patterns`);
     if (!matchConfigs.length ||
         !matchConfigs.some(configOption => Object.keys(configOption).length)) {
@@ -1176,7 +1171,7 @@ function checkAll(matchConfigs, changedFiles, dot) {
     }
     for (const matchConfig of matchConfigs) {
         if (matchConfig.baseBranch) {
-            if (!(0, branch_1.checkAllBranch)(matchConfig.baseBranch, 'base')) {
+            if (!(0, branch_1.checkAllBranch)(prData, matchConfig.baseBranch, 'base')) {
                 core.debug(`  "all" patterns did not match`);
                 return false;
             }
@@ -1192,7 +1187,7 @@ function checkAll(matchConfigs, changedFiles, dot) {
             }
         }
         if (matchConfig.headBranch) {
-            if (!(0, branch_1.checkAllBranch)(matchConfig.headBranch, 'head')) {
+            if (!(0, branch_1.checkAllBranch)(prData, matchConfig.headBranch, 'head')) {
                 core.debug(`  "all" patterns did not match`);
                 return false;
             }

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as github from '@actions/github';
 
 export interface BranchMatchConfig {
   headBranch?: string[];
@@ -27,24 +26,23 @@ export function toBranchMatchConfig(config: any): BranchMatchConfig {
   return branchConfig;
 }
 
-export function getBranchName(branchBase: BranchBase): string | undefined {
-  const pullRequest = github.context.payload.pull_request;
-  if (!pullRequest) {
-    return undefined;
-  }
-
+export function getBranchName(
+  prData: any,
+  branchBase: BranchBase
+): string | undefined {
   if (branchBase === 'base') {
-    return pullRequest.base?.ref;
+    return prData.base?.ref;
   } else {
-    return pullRequest.head?.ref;
+    return prData.head?.ref;
   }
 }
 
 export function checkAnyBranch(
+  prData: any,
   regexps: string[],
   branchBase: BranchBase
 ): boolean {
-  const branchName = getBranchName(branchBase);
+  const branchName = getBranchName(prData, branchBase);
   if (!branchName) {
     core.debug(`   no branch name`);
     return false;
@@ -64,10 +62,11 @@ export function checkAnyBranch(
 }
 
 export function checkAllBranch(
+  prData: any,
   regexps: string[],
   branchBase: BranchBase
 ): boolean {
-  const branchName = getBranchName(branchBase);
+  const branchName = getBranchName(prData, branchBase);
   if (!branchName) {
     core.debug(`   cannot fetch branch name from the pull request`);
     return false;

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -44,7 +44,14 @@ async function labeler() {
 
     for (const [label, configs] of labelConfigs.entries()) {
       core.debug(`processing ${label}`);
-      if (checkMatchConfigs(pullRequest.changedFiles, configs, dot)) {
+      if (
+        checkMatchConfigs(
+          pullRequest.data,
+          pullRequest.changedFiles,
+          configs,
+          dot
+        )
+      ) {
         allLabels.add(label);
       } else if (syncLabels) {
         allLabels.delete(label);
@@ -98,13 +105,14 @@ async function labeler() {
 }
 
 export function checkMatchConfigs(
+  prData: any,
   changedFiles: string[],
   matchConfigs: MatchConfig[],
   dot: boolean
 ): boolean {
   for (const config of matchConfigs) {
     core.debug(` checking config ${JSON.stringify(config)}`);
-    if (!checkMatch(changedFiles, config, dot)) {
+    if (!checkMatch(prData, changedFiles, config, dot)) {
       return false;
     }
   }
@@ -113,6 +121,7 @@ export function checkMatchConfigs(
 }
 
 function checkMatch(
+  prData: any,
   changedFiles: string[],
   matchConfig: MatchConfig,
   dot: boolean
@@ -123,13 +132,13 @@ function checkMatch(
   }
 
   if (matchConfig.all) {
-    if (!checkAll(matchConfig.all, changedFiles, dot)) {
+    if (!checkAll(matchConfig.all, prData, changedFiles, dot)) {
       return false;
     }
   }
 
   if (matchConfig.any) {
-    if (!checkAny(matchConfig.any, changedFiles, dot)) {
+    if (!checkAny(matchConfig.any, prData, changedFiles, dot)) {
       return false;
     }
   }
@@ -140,6 +149,7 @@ function checkMatch(
 // equivalent to "Array.some()" but expanded for debugging and clarity
 export function checkAny(
   matchConfigs: BaseMatchConfig[],
+  prData: any,
   changedFiles: string[],
   dot: boolean
 ): boolean {
@@ -154,7 +164,7 @@ export function checkAny(
 
   for (const matchConfig of matchConfigs) {
     if (matchConfig.baseBranch) {
-      if (checkAnyBranch(matchConfig.baseBranch, 'base')) {
+      if (checkAnyBranch(prData, matchConfig.baseBranch, 'base')) {
         core.debug(`  "any" patterns matched`);
         return true;
       }
@@ -168,7 +178,7 @@ export function checkAny(
     }
 
     if (matchConfig.headBranch) {
-      if (checkAnyBranch(matchConfig.headBranch, 'head')) {
+      if (checkAnyBranch(prData, matchConfig.headBranch, 'head')) {
         core.debug(`  "any" patterns matched`);
         return true;
       }
@@ -182,6 +192,7 @@ export function checkAny(
 // equivalent to "Array.every()" but expanded for debugging and clarity
 export function checkAll(
   matchConfigs: BaseMatchConfig[],
+  prData: any,
   changedFiles: string[],
   dot: boolean
 ): boolean {
@@ -196,7 +207,7 @@ export function checkAll(
 
   for (const matchConfig of matchConfigs) {
     if (matchConfig.baseBranch) {
-      if (!checkAllBranch(matchConfig.baseBranch, 'base')) {
+      if (!checkAllBranch(prData, matchConfig.baseBranch, 'base')) {
         core.debug(`  "all" patterns did not match`);
         return false;
       }
@@ -215,7 +226,7 @@ export function checkAll(
     }
 
     if (matchConfig.headBranch) {
-      if (!checkAllBranch(matchConfig.headBranch, 'head')) {
+      if (!checkAllBranch(prData, matchConfig.headBranch, 'head')) {
         core.debug(`  "all" patterns did not match`);
         return false;
       }


### PR DESCRIPTION
**Description:**

Changed to get branch name from pull request response.
This allows labeling with head-branch/base-branch rules outside of pull_request events.

e.g.

```yaml
on:
  workflow_dispatch:
    inputs:
      pr-number:

jobs:
  labeler:
    permissions:
      contents: read
      pull-requests: write
    runs-on: ubuntu-latest
    steps:
    - uses: actions/labeler@v5
      with:
        pr-number: ${{ inputs.pr-number }}
```

**Related issue:**

#810

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.