### PR TITLE
Update Node.js version to 24 in action and dependencies

### DIFF
--- a/.github/workflows/basic-validation.yml
+++ b/.github/workflows/basic-validation.yml
@@ -16,4 +16,4 @@ jobs:
     name: Basic validation
     uses: actions/reusable-workflows/.github/workflows/basic-validation.yml@main
     with:
-      node-version: '20.x'
+      node-version: '24.x'

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -16,4 +16,4 @@ jobs:
     name: Check dist/
     uses: actions/reusable-workflows/.github/workflows/check-dist.yml@main
     with:
-      node-version: '20.x'
+      node-version: '24.x'

--- a/.github/workflows/publish-immutable-actions.yml
+++ b/.github/workflows/publish-immutable-actions.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checking out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Publish
         id: publish
         uses: actions/publish-immutable-action@0.0.3

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6
 ```
 
 #### Inputs
@@ -182,10 +182,10 @@ You might want to use action called [@actions/checkout](https://github.com/actio
 
 ```yml
     steps:
-    - uses: actions/checkout@v4 # Uploads repository content to the runner
+    - uses: actions/checkout@v5 # Uploads repository content to the runner
       with:
         repository: "owner/repositoryName" # The one of the available inputs, visit https://github.com/actions/checkout#readme to find more
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6
       with:
         configuration-path: 'path/to/the/uploaded/configuration/file'
 
@@ -208,7 +208,7 @@ jobs:
     steps:
     
     # Label PRs 1, 2, and 3
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6
       with:        
         pr-number: |
           1
@@ -241,7 +241,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - id: label-the-PR
-      uses: actions/labeler@v5
+      uses: actions/labeler@v6
       
     - id: run-frontend-tests
       if: contains(steps.label-the-PR.outputs.all-labels, 'frontend')

--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ outputs:
   all-labels:
     description: 'A comma-separated list of all labels that the PR contains'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/lodash.isequal": "^4.5.8",
         "@types/minimatch": "^5.1.2",
-        "@types/node": "^20.11.30",
+        "@types/node": "^24.1.0",
         "@typescript-eslint/eslint-plugin": "^7.3.1",
         "@typescript-eslint/parser": "^7.18.0",
         "@vercel/ncc": "^0.38.3",
@@ -33,6 +33,9 @@
         "prettier": "^3.4.2",
         "ts-jest": "^29.2.5",
         "typescript": "^5.7.3"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1652,12 +1655,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/semver": {
@@ -5356,10 +5360,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "labeler",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "labeler",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "5.0.0",
   "description": "Labels pull requests by files altered",
   "main": "lib/main.js",
+    "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "tsc && ncc build lib/main.js",
     "format": "prettier --no-error-on-unmatched-pattern --config ./.prettierrc.js --write \"**/*.{ts,yml,yaml}\"",
@@ -36,7 +39,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/lodash.isequal": "^4.5.8",
     "@types/minimatch": "^5.1.2",
-    "@types/node": "^20.11.30",
+    "@types/node": "^24.1.0",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.18.0",
     "@vercel/ncc": "^0.38.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labeler",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Labels pull requests by files altered",
   "main": "lib/main.js",
     "engines": {


### PR DESCRIPTION
Bump the required Node.js version to 24 in action.yml and package.json. Update @types/node to ^24.1.0 to match the new Node.js version.

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.