### PR TITLE
Fix: Preserve manually added labels during workflow run and refine label sync logic

### DIFF
--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -54,27 +54,28 @@ export async function labeler() {
     const labelsToApply = [...allLabels].slice(0, GITHUB_MAX_LABELS);
     const excessLabels = [...allLabels].slice(GITHUB_MAX_LABELS);
 
-    let finalLabels = Array.from(new Set(labelsToApply));
+    let finalLabels = labelsToApply;
     let newLabels: string[] = [];
 
     try {
       if (!isEqual(labelsToApply, preexistingLabels)) {
         // Fetch the latest labels for the PR
         const latestLabels: string[] = [];
+        // Skip fetching real labels when running tests (uses mock data instead)
         if (process.env.NODE_ENV !== 'test') {
           const pr = await client.rest.pulls.get({
             ...github.context.repo,
             pull_number: pullRequest.number
           });
-          latestLabels.push(...pr.data.labels.map(l => l.name));
+          latestLabels.push(...pr.data.labels.map(l => l.name).filter(Boolean));
         }
 
-        //Detect labels manually added or added by other bots during the run.
+        // Labels added manually during the run (not in first snapshot)
         const manualAddedDuringRun = latestLabels.filter(
           l => !preexistingLabels.includes(l)
         );
 
-        // Merge manual and config-based labels (dedupe + limit)
+        // Preserve manual labels first, then apply config-based labels, respecting GitHub's 100-label limit
         finalLabels = [
           ...new Set([...manualAddedDuringRun, ...labelsToApply])
         ].slice(0, GITHUB_MAX_LABELS);


### PR DESCRIPTION
**Description:**
This pull request updates the `labeler` function to improve how labels are managed and applied to pull requests, especially when labels may have been added manually or by other bots during the workflow run.

**Label management improvements:**

* The label application logic now fetches the latest labels from the pull request before applying new ones, so it can detect labels that were manually added or added by other bots during the workflow run. It merges these with the labels determined by the config, deduplicates them, and enforces the maximum label limit (`GITHUB_MAX_LABELS`).
* The output for `all-labels` now reflects the final set of labels actually applied to the pull request, ensuring outputs are accurate and up-to-date..

**Related issue:**
(https://github.com/actions/labeler/issues/908 , https://github.com/actions/labeler/issues/763).

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.