### PR TITLE
Fix logical operator bug in PR number validation (#28)

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -441,6 +441,42 @@ describe('run', () => {
     );
   });
 
+  it('(with pr-number: non-numeric value) warns and skips invalid PR numbers', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': ['not-a-number']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+    mockGitHubResponseChangedFiles('foo.pdf');
+
+    await run();
+
+    expect(setLabelsMock).toHaveBeenCalledTimes(0);
+    expect(coreWarningMock).toHaveBeenCalledWith(
+      `'NaN' is not a valid pull request number`
+    );
+  });
+
+  it('(with pr-number: negative value) warns and skips negative PR numbers', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': ['-5']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+    mockGitHubResponseChangedFiles('foo.pdf');
+
+    await run();
+
+    expect(setLabelsMock).toHaveBeenCalledTimes(0);
+    expect(coreWarningMock).toHaveBeenCalledWith(
+      `'-5' is not a valid pull request number`
+    );
+  });
+
   it('does not add labels to PRs that have no changed files', async () => {
     usingLabelerConfigYaml('only_pdfs.yml');
     mockGitHubResponseChangedFiles();

--- a/dist/index.js
+++ b/dist/index.js
@@ -1003,7 +1003,7 @@ const getPrNumbers = () => {
     const result = [];
     for (const line of prInput) {
         const prNumber = parseInt(line, 10);
-        if (isNaN(prNumber) && prNumber <= 0) {
+        if (isNaN(prNumber) || prNumber <= 0) {
             core.warning(`'${prNumber}' is not a valid pull request number`);
             continue;
         }

--- a/src/get-inputs/get-pr-numbers.ts
+++ b/src/get-inputs/get-pr-numbers.ts
@@ -16,7 +16,7 @@ export const getPrNumbers = (): number[] => {
   for (const line of prInput) {
     const prNumber = parseInt(line, 10);
 
-    if (isNaN(prNumber) && prNumber <= 0) {
+    if (isNaN(prNumber) || prNumber <= 0) {
       core.warning(`'${prNumber}' is not a valid pull request number`);
       continue;
     }


### PR DESCRIPTION
* Initial plan

* Fix PR number validation logic: change && to || in isNaN/<=0 check

Fixes Bad Check against PR Number #937

Agent-Logs-Url: https://github.com/chaoscommencer/labeler/sessions/dea87170-64ac-48de-888f-06742907af74



---------

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.