### PR TITLE
fix: use compare API to avoid incorrect labeling from merge commits

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -23,6 +23,7 @@ const addLabelsRequestMock = jest.fn<any>(options => {
 const removeLabelsMock = jest.fn<any>();
 const setLabelsMock = jest.fn<any>();
 const reposMock = jest.fn<any>();
+const compareCommitsWithBaseheadMock = jest.fn<any>();
 const paginateMock = jest.fn<any>();
 const getPullMock = jest.fn<any>().mockResolvedValue({data: {labels: []}});
 const listFilesMergeMock = jest.fn<any>().mockReturnValue({});
@@ -67,7 +68,10 @@ jest.unstable_mockModule('@actions/github', () => ({
         addLabels: addLabelsRequestMock,
         setLabels: setLabelsMock
       },
-      repos: {getContent: reposMock},
+      repos: {
+        getContent: reposMock,
+        compareCommitsWithBasehead: compareCommitsWithBaseheadMock
+      },
       pulls: {
         get: getPullMock,
         listFiles: {endpoint: {merge: listFilesMergeMock}}
@@ -1164,6 +1168,96 @@ describe('run', () => {
       expect(coreSetFailedMock).toHaveBeenCalledWith(error.message);
     }
   );
+  it('uses compare API when PR data includes base ref and head sha', async () => {
+    configureInput({});
+    usingLabelerConfigYaml('only_pdfs.yml');
+
+    getPullMock.mockResolvedValue(<any>{
+      data: {
+        labels: [],
+        base: {ref: 'main'},
+        head: {sha: 'abc123'}
+      }
+    });
+
+    compareCommitsWithBaseheadMock.mockResolvedValue({
+      data: {
+        files: [{filename: 'foo.pdf'}]
+      }
+    });
+
+    await run();
+
+    expect(compareCommitsWithBaseheadMock).toHaveBeenCalledWith({
+      owner: 'monalisa',
+      repo: 'helloworld',
+      basehead: 'main...abc123'
+    });
+    expect(addLabelsMock).toHaveBeenCalledTimes(1);
+    expect(addLabelsMock).toHaveBeenCalledWith({
+      owner: 'monalisa',
+      repo: 'helloworld',
+      issue_number: 123,
+      labels: ['touched-a-pdf-file']
+    });
+  });
+
+  it('falls back to listFiles when compare API returns 300+ files', async () => {
+    configureInput({});
+    usingLabelerConfigYaml('only_pdfs.yml');
+
+    getPullMock.mockResolvedValue(<any>{
+      data: {
+        labels: [],
+        base: {ref: 'main'},
+        head: {sha: 'abc123'}
+      }
+    });
+
+    const manyFiles = Array.from({length: 300}, (_, i) => ({
+      filename: `file${i}.ts`
+    }));
+    compareCommitsWithBaseheadMock.mockResolvedValue({
+      data: {files: manyFiles}
+    });
+
+    mockGitHubResponseChangedFiles('foo.pdf');
+
+    await run();
+
+    expect(compareCommitsWithBaseheadMock).toHaveBeenCalled();
+    expect(paginateMock).toHaveBeenCalled();
+    expect(addLabelsMock).toHaveBeenCalledTimes(1);
+    expect(addLabelsMock).toHaveBeenCalledWith({
+      owner: 'monalisa',
+      repo: 'helloworld',
+      issue_number: 123,
+      labels: ['touched-a-pdf-file']
+    });
+  });
+
+  it('falls back to listFiles when PR data lacks base ref', async () => {
+    configureInput({});
+    usingLabelerConfigYaml('only_pdfs.yml');
+    mockGitHubResponseChangedFiles('foo.pdf');
+
+    getPullMock.mockResolvedValue(<any>{
+      data: {
+        labels: []
+      }
+    });
+
+    await run();
+
+    expect(compareCommitsWithBaseheadMock).not.toHaveBeenCalled();
+    expect(addLabelsMock).toHaveBeenCalledTimes(1);
+    expect(addLabelsMock).toHaveBeenCalledWith({
+      owner: 'monalisa',
+      repo: 'helloworld',
+      issue_number: 123,
+      labels: ['touched-a-pdf-file']
+    });
+  });
 });
 
 function usingLabelerConfigYaml(fixtureName: keyof typeof yamlFixtures): void {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38187,7 +38187,31 @@ const addLabels = async (client, prNumber, labels) => {
 ;// CONCATENATED MODULE: ./lib/api/get-changed-files.js
 
 
-const getChangedFiles = async (client, prNumber) => {
+const COMPARE_API_FILE_LIMIT = 300;
+const getChangedFiles = async (client, prNumber, baseRef, headSha) => {
+    if (baseRef && headSha) {
+        core_debug(`using compare API for pr #${prNumber}: ${baseRef}...${headSha}`);
+        const response = await client.rest.repos.compareCommitsWithBasehead({
+            owner: github_context.repo.owner,
+            repo: github_context.repo.repo,
+            basehead: `${baseRef}...${headSha}`
+        });
+        const compareFiles = (response.data.files ?? []).map(f => f.filename);
+        if (compareFiles.length >= COMPARE_API_FILE_LIMIT) {
+            info(`compare API returned ${compareFiles.length} files (at or above ${COMPARE_API_FILE_LIMIT} limit), ` +
+                `falling back to pulls.listFiles for pr #${prNumber}`);
+            return getChangedFilesFromListFiles(client, prNumber);
+        }
+        core_debug('found changed files (compare):');
+        for (const file of compareFiles) {
+            core_debug('  ' + file);
+        }
+        return compareFiles;
+    }
+    return getChangedFilesFromListFiles(client, prNumber);
+};
+const getChangedFilesFromListFiles = async (client, prNumber) => {
+    core_debug(`using pulls.listFiles for pr #${prNumber}`);
     const listFilesOptions = client.rest.pulls.listFiles.endpoint.merge({
         owner: github_context.repo.owner,
         repo: github_context.repo.repo,
@@ -38223,7 +38247,7 @@ async function* getPullRequests(client, prNumbers) {
             continue;
         }
         core_debug(`fetching changed files for pr #${prNumber}`);
-        const changedFiles = await getChangedFiles(client, prNumber);
+        const changedFiles = await getChangedFiles(client, prNumber, prData.base?.ref, prData.head?.sha);
         if (!changedFiles.length) {
             warning(`Pull request #${prNumber} has no changed files, skipping`);
             continue;

--- a/src/api/get-changed-files.ts
+++ b/src/api/get-changed-files.ts
@@ -2,10 +2,50 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 import {ClientType} from './types.js';
 
+const COMPARE_API_FILE_LIMIT = 300;
+
 export const getChangedFiles = async (
+  client: ClientType,
+  prNumber: number,
+  baseRef?: string,
+  headSha?: string
+): Promise<string[]> => {
+  if (baseRef && headSha) {
+    core.debug(
+      `using compare API for pr #${prNumber}: ${baseRef}...${headSha}`
+    );
+    const response = await client.rest.repos.compareCommitsWithBasehead({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      basehead: `${baseRef}...${headSha}`
+    });
+
+    const compareFiles = (response.data.files ?? []).map(f => f.filename);
+
+    if (compareFiles.length >= COMPARE_API_FILE_LIMIT) {
+      core.info(
+        `compare API returned ${compareFiles.length} files (at or above ${COMPARE_API_FILE_LIMIT} limit), ` +
+          `falling back to pulls.listFiles for pr #${prNumber}`
+      );
+      return getChangedFilesFromListFiles(client, prNumber);
+    }
+
+    core.debug('found changed files (compare):');
+    for (const file of compareFiles) {
+      core.debug('  ' + file);
+    }
+
+    return compareFiles;
+  }
+
+  return getChangedFilesFromListFiles(client, prNumber);
+};
+
+const getChangedFilesFromListFiles = async (
   client: ClientType,
   prNumber: number
 ): Promise<string[]> => {
+  core.debug(`using pulls.listFiles for pr #${prNumber}`);
   const listFilesOptions = client.rest.pulls.listFiles.endpoint.merge({
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,

--- a/src/api/get-changed-pull-requests.ts
+++ b/src/api/get-changed-pull-requests.ts
@@ -23,7 +23,12 @@ export async function* getPullRequests(
     }
 
     core.debug(`fetching changed files for pr #${prNumber}`);
-    const changedFiles: string[] = await getChangedFiles(client, prNumber);
+    const changedFiles: string[] = await getChangedFiles(
+      client,
+      prNumber,
+      prData.base?.ref,
+      prData.head?.sha
+    );
     if (!changedFiles.length) {
       core.warning(`Pull request #${prNumber} has no changed files, skipping`);
       continue;


### PR DESCRIPTION
**Description:**

When a PR merges its base branch (e.g. main) into the feature branch, pulls.listFiles returns files from the base branch in the diff, causing spurious labels to be applied. This is because pulls.listFiles computes changes relative to a cached merge base that may not reflect the current state of the base branch after a merge-from-base commit.

This PR switches the file detection to use the compare API (repos.compareCommitsWithBasehead), which computes the diff against the current tip of the base branch, returning only files the PR author actually changed.

The compare API returns a maximum of 300 files. If the response hits this limit, the action falls back to pulls.listFiles to ensure large PRs are still fully labeled. The fallback also applies when base ref or head SHA are unavailable (backward compatible with existing behavior).


Describe your changes.

**Related issue:**
[Fixes #784](https://github.com/actions/labeler/issues/784)

**Check list:**
- [ ] Mark if documentation changes are required.
- [X] Mark if tests were added or updated to cover the changes.